### PR TITLE
🔨 PR MyPage 데이터 및 일부 기능 연결

### DIFF
--- a/toondo/lib/main.dart
+++ b/toondo/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:get_it/get_it.dart';
 import 'package:presentation/viewmodels/character/chat_viewmodel.dart';
+import 'package:presentation/viewmodels/global/app_notification_viewmodel.dart';
 import 'package:presentation/viewmodels/onboarding/onboarding_viewmodel.dart';
 import 'package:provider/provider.dart';
 import 'package:permission_handler/permission_handler.dart';
@@ -39,15 +40,19 @@ Future<void> main() async {
   // 테마 공통 관리
   final themeVM = GetIt.instance<AppThemeViewModel>();
   await themeVM.load();
-  print('Current theme mode: ${themeVM.mode}');
 
-  runApp(MyApp(themeVM: themeVM));
+  // 알림 공통 관리
+  final notificationVM = GetIt.instance<AppNotificationViewModel>();
+  await notificationVM.load();
+
+  runApp(MyApp(themeVM: themeVM, notificationVM: notificationVM));
 }
 
 class MyApp extends StatefulWidget {
   final AppThemeViewModel themeVM;
+  final AppNotificationViewModel notificationVM;
 
-  const MyApp({super.key, required this.themeVM});
+  const MyApp({super.key, required this.themeVM, required this.notificationVM});
 
   @override
   MyAppState createState() => MyAppState();
@@ -61,7 +66,10 @@ class MyAppState extends State<MyApp> {
     super.initState();
 
     widget.themeVM.addListener(() {
-      print('[MyAppState] themeVM changed, calling setState()'); // ✅ 추가
+      setState(() {});
+    });
+
+    widget.notificationVM.addListener(() {
       setState(() {});
     });
 
@@ -75,6 +83,7 @@ class MyAppState extends State<MyApp> {
     return MultiProvider(
       providers: [
         ChangeNotifierProvider(create: (_) => widget.themeVM),
+        ChangeNotifierProvider(create: (_) => widget.notificationVM),
         ChangeNotifierProvider(
             create: (_) => GetIt.instance<SignupViewModel>()),
         ChangeNotifierProvider(

--- a/toondo/lib/main.dart
+++ b/toondo/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:domain/entities/theme_mode_type.dart';
 import 'package:flutter/material.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:get_it/get_it.dart';
@@ -8,6 +9,7 @@ import 'package:permission_handler/permission_handler.dart';
 import 'package:presentation/navigation/router.dart';
 import 'package:presentation/viewmodels/signup/signup_viewmodel.dart';
 import 'package:presentation/viewmodels/home/home_viewmodel.dart';
+import 'package:presentation/viewmodels/global/app_theme_viewmodel.dart';
 import 'package:presentation/viewmodels/goal/goal_management_viewmodel.dart';
 import 'package:data/models/todo_model.dart';
 import 'package:data/models/user_model.dart';
@@ -34,11 +36,19 @@ Future<void> main() async {
   // 의존성 주입
   await configureAllDependencies();
 
-  runApp(const MyApp());
+  // 테마 공통 관리
+  final themeVM = GetIt.instance<AppThemeViewModel>();
+  await themeVM.load();
+  print('Current theme mode: ${themeVM.mode}');
+
+  runApp(MyApp(themeVM: themeVM));
 }
 
 class MyApp extends StatefulWidget {
-  const MyApp({super.key});
+  final AppThemeViewModel themeVM;
+
+  const MyApp({super.key, required this.themeVM});
+
   @override
   MyAppState createState() => MyAppState();
 }
@@ -49,10 +59,14 @@ class MyAppState extends State<MyApp> {
   @override
   void initState() {
     super.initState();
-    // 알림 권한 확인 등 초기화
+
+    widget.themeVM.addListener(() {
+      print('[MyAppState] themeVM changed, calling setState()'); // ✅ 추가
+      setState(() {});
+    });
+
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       await Permission.notification.status;
-      // 필요 시 권한 요청
     });
   }
 
@@ -60,6 +74,7 @@ class MyAppState extends State<MyApp> {
   Widget build(BuildContext context) {
     return MultiProvider(
       providers: [
+        ChangeNotifierProvider(create: (_) => widget.themeVM),
         ChangeNotifierProvider(
             create: (_) => GetIt.instance<SignupViewModel>()),
         ChangeNotifierProvider(
@@ -69,11 +84,17 @@ class MyAppState extends State<MyApp> {
         ChangeNotifierProvider(
             create: (_) => GetIt.instance<OnboardingViewModel>()),
       ],
-      child: MaterialApp(
-        navigatorKey: navigatorKey,
-        initialRoute: '/',
-        onGenerateRoute: AppRouter.generateRoute,
-        theme: ThemeData()
+      child: Consumer<AppThemeViewModel>(
+        builder: (context, vm, _) {
+          return MaterialApp(
+            themeMode: vm.mode.toFlutterMode(),
+            navigatorKey: navigatorKey,
+            initialRoute: '/',
+            onGenerateRoute: AppRouter.generateRoute,
+            theme: ThemeData.light(),
+            darkTheme: ThemeData.dark(),
+          );
+        },
       ),
     );
   }

--- a/toondo/lib/main.dart
+++ b/toondo/lib/main.dart
@@ -97,10 +97,12 @@ class MyAppState extends State<MyApp> {
         builder: (context, vm, _) {
           return MaterialApp(
             themeMode: vm.mode.toFlutterMode(),
+            theme: ThemeData.light().copyWith(
+              scaffoldBackgroundColor: const Color(0xFFFDFDFD), // 라이트 모드 배경색
+            ),
             navigatorKey: navigatorKey,
             initialRoute: '/',
             onGenerateRoute: AppRouter.generateRoute,
-            theme: ThemeData.light(),
             darkTheme: ThemeData.dark(),
           );
         },

--- a/toondo/packages/data/lib/datasources/local/user_local_datasource.dart
+++ b/toondo/packages/data/lib/datasources/local/user_local_datasource.dart
@@ -19,6 +19,11 @@ class UserLocalDatasource {
     return model?.getNickname();
   }
 
+  Future<User> getUser() async {
+    final model = userBox.get('currentUser');
+    return model!.toEntity();
+  }
+
   Future<void> updateUserPoints(int newPoint) async {
     final model = userBox.get('currentUser');
     if (model != null) {
@@ -34,6 +39,4 @@ class UserLocalDatasource {
       await userBox.put('currentUser', model);
     }
   }
-
-  // ...other local methods if needed...
 }

--- a/toondo/packages/data/lib/injection/di.config.dart
+++ b/toondo/packages/data/lib/injection/di.config.dart
@@ -32,6 +32,7 @@ import 'package:data/repositories/goal_repository_impl.dart' as _i527;
 import 'package:data/repositories/slime_character_repository_impl.dart'
     as _i409;
 import 'package:data/repositories/sms_repository_impl.dart' as _i235;
+import 'package:data/repositories/theme_repository_impl.dart' as _i525;
 import 'package:data/repositories/todo_repository_impl.dart' as _i366;
 import 'package:data/repositories/user_repository_impl.dart' as _i537;
 import 'package:data/utils/gesture_mapper.dart' as _i587;
@@ -40,6 +41,7 @@ import 'package:domain/repositories/character_repository.dart' as _i434;
 import 'package:domain/repositories/goal_repository.dart' as _i559;
 import 'package:domain/repositories/slime_repository.dart' as _i657;
 import 'package:domain/repositories/sms_repository.dart' as _i366;
+import 'package:domain/repositories/theme_repository.dart' as _i578;
 import 'package:domain/repositories/todo_repository.dart' as _i158;
 import 'package:domain/repositories/user_repository.dart' as _i988;
 import 'package:flutter_secure_storage/flutter_secure_storage.dart' as _i558;
@@ -47,6 +49,7 @@ import 'package:get_it/get_it.dart' as _i174;
 import 'package:hive/hive.dart' as _i979;
 import 'package:http/http.dart' as _i519;
 import 'package:injectable/injectable.dart' as _i526;
+import 'package:shared_preferences/shared_preferences.dart' as _i460;
 
 extension GetItInjectableX on _i174.GetIt {
 // initializes the registration of main-scope dependencies inside of GetIt
@@ -70,6 +73,10 @@ extension GetItInjectableX on _i174.GetIt {
     );
     await gh.factoryAsync<_i979.Box<_i934.GoalStatusEnum>>(
       () => registerModule.goalStatusBox,
+      preResolve: true,
+    );
+    await gh.factoryAsync<_i460.SharedPreferences>(
+      () => registerModule.sharedPreferences,
       preResolve: true,
     );
     gh.lazySingleton<_i938.AnimationLocalDataSource>(
@@ -96,6 +103,8 @@ extension GetItInjectableX on _i174.GetIt {
         () => _i1024.UserLocalDatasource(gh<_i979.Box<_i245.UserModel>>()));
     gh.lazySingleton<_i116.AuthLocalDataSource>(
         () => _i116.AuthLocalDataSource(gh<_i979.Box<_i245.UserModel>>()));
+    gh.lazySingleton<_i578.ThemeRepository>(
+        () => _i525.ThemeRepositoryImpl(gh<_i460.SharedPreferences>()));
     gh.lazySingleton<_i361.SecureLocalDataSource>(
         () => _i361.SecureLocalDataSource(gh<_i558.FlutterSecureStorage>()));
     gh.lazySingleton<_i91.TodoLocalDatasource>(() => _i91.TodoLocalDatasource(

--- a/toondo/packages/data/lib/injection/di.config.dart
+++ b/toondo/packages/data/lib/injection/di.config.dart
@@ -29,6 +29,7 @@ import 'package:data/models/user_model.dart' as _i245;
 import 'package:data/repositories/auth_repository_impl.dart' as _i819;
 import 'package:data/repositories/character_repository_impl.dart' as _i919;
 import 'package:data/repositories/goal_repository_impl.dart' as _i527;
+import 'package:data/repositories/notification_repository_impl.dart' as _i15;
 import 'package:data/repositories/slime_character_repository_impl.dart'
     as _i409;
 import 'package:data/repositories/sms_repository_impl.dart' as _i235;
@@ -39,6 +40,7 @@ import 'package:data/utils/gesture_mapper.dart' as _i587;
 import 'package:domain/repositories/auth_repository.dart' as _i427;
 import 'package:domain/repositories/character_repository.dart' as _i434;
 import 'package:domain/repositories/goal_repository.dart' as _i559;
+import 'package:domain/repositories/notification_repository.dart' as _i267;
 import 'package:domain/repositories/slime_repository.dart' as _i657;
 import 'package:domain/repositories/sms_repository.dart' as _i366;
 import 'package:domain/repositories/theme_repository.dart' as _i578;
@@ -92,6 +94,8 @@ extension GetItInjectableX on _i174.GetIt {
     );
     gh.lazySingleton<_i954.AuthRemoteDataSource>(
         () => _i954.AuthRemoteDataSource(gh<_i519.Client>()));
+    gh.lazySingleton<_i267.NotificationSettingRepository>(() =>
+        _i15.NotificationSettingRepositoryImpl(gh<_i460.SharedPreferences>()));
     await gh.factoryAsync<_i979.Box<_i923.TodoModel>>(
       () => registerModule.todoBox,
       instanceName: 'todoBox',

--- a/toondo/packages/data/lib/injection/di_module.dart
+++ b/toondo/packages/data/lib/injection/di_module.dart
@@ -7,27 +7,39 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:hive/hive.dart';
 import 'package:injectable/injectable.dart';
 import 'package:http/http.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 @module
 abstract class RegisterModule {
   @lazySingleton
   Client get httpClient => Client();
+
   @preResolve
   Future<Box<UserModel>> get userBox => Hive.openBox<UserModel>('users');
+
   @preResolve
   @Named('todoBox')
   Future<Box<TodoModel>> get todoBox => Hive.openBox<TodoModel>('todos');
+
   @preResolve
   @Named('deletedTodoBox')
   Future<Box<TodoModel>> get deletedTodoBox =>
       Hive.openBox<TodoModel>('deleted_todos');
+
   @preResolve
   Future<Box<GoalModel>> get goalBox => Hive.openBox<GoalModel>('goals');
+
   @preResolve
   Future<Box<GoalStatusEnum>> get goalStatusBox =>
       Hive.openBox<GoalStatusEnum>('goalStatus');
+
   @lazySingleton
   FlutterSecureStorage get secureStorage => FlutterSecureStorage();
+
   @lazySingleton
   GestureMapper get gestureMapper => const GestureMapper();
+
+  @preResolve
+  Future<SharedPreferences> get sharedPreferences =>
+      SharedPreferences.getInstance();
 }

--- a/toondo/packages/data/lib/models/user_model.dart
+++ b/toondo/packages/data/lib/models/user_model.dart
@@ -17,16 +17,26 @@ class UserModel extends HiveObject {
   @HiveField(3)
   int points;
 
+  @HiveField(4)
+  String? phoneNumber;
+
   UserModel({
     required this.id,
     required this.loginId,
     this.nickname,
     required this.points,
+    this.phoneNumber,
   });
 
   // Convert model to domain entity
   User toEntity() {
-    return User(id: id, loginId: loginId, nickname: nickname, points: points);
+    return User(
+      id: id,
+      loginId: loginId,
+      nickname: nickname,
+      points: points,
+      phoneNumber: phoneNumber,
+    );
   }
 
   // Create model from domain entity
@@ -36,6 +46,7 @@ class UserModel extends HiveObject {
       loginId: user.loginId,
       nickname: user.nickname,
       points: user.points,
+      phoneNumber: user.phoneNumber,
     );
   }
 
@@ -46,6 +57,7 @@ class UserModel extends HiveObject {
       loginId: json['loginId'] as String,
       nickname: json['nickname'] as String?,
       points: json['points'] as int,
+   //   phoneNumber: json['phoneNumber'] as String?,
     );
   }
 

--- a/toondo/packages/data/lib/models/user_model.g.dart
+++ b/toondo/packages/data/lib/models/user_model.g.dart
@@ -21,13 +21,14 @@ class UserModelAdapter extends TypeAdapter<UserModel> {
       loginId: fields[1] as String,
       nickname: fields[2] as String?,
       points: fields[3] as int,
+      phoneNumber: fields[4] as String?,
     );
   }
 
   @override
   void write(BinaryWriter writer, UserModel obj) {
     writer
-      ..writeByte(4)
+      ..writeByte(5)
       ..writeByte(0)
       ..write(obj.id)
       ..writeByte(1)
@@ -35,7 +36,9 @@ class UserModelAdapter extends TypeAdapter<UserModel> {
       ..writeByte(2)
       ..write(obj.nickname)
       ..writeByte(3)
-      ..write(obj.points);
+      ..write(obj.points)
+      ..writeByte(4)
+      ..write(obj.phoneNumber);
   }
 
   @override

--- a/toondo/packages/data/lib/repositories/notification_repository_impl.dart
+++ b/toondo/packages/data/lib/repositories/notification_repository_impl.dart
@@ -1,0 +1,42 @@
+import 'package:injectable/injectable.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:domain/repositories/notification_repository.dart';
+import 'package:domain/entities/notification_settings.dart';
+
+@LazySingleton(as: NotificationSettingRepository)
+class NotificationSettingRepositoryImpl implements NotificationSettingRepository {
+  final SharedPreferences prefs;
+
+  NotificationSettingRepositoryImpl(this.prefs);
+
+  static const _sound = 'notification_sound';
+  static const _all = 'notification_all';
+  static const _report = 'notification_report';
+  static const _reminder = 'notification_reminder';
+  static const _time = 'notification_time';
+
+  @override
+  Future<NotificationSettings> getSettings() async {
+    return NotificationSettings(
+      sound: prefs.getBool(_sound) ?? true,
+      all: prefs.getBool(_all) ?? true,
+      report: prefs.getBool(_report) ?? true,
+      reminder: prefs.getBool(_reminder) ?? true,
+      time: prefs.getString(_time) ?? '03:00',
+    );
+  }
+
+  @override
+  Future<void> setSettings(NotificationSettings settings) async {
+    await prefs.setBool(_sound, settings.sound);
+    await prefs.setBool(_all, settings.all);
+    await prefs.setBool(_report, settings.report);
+    await prefs.setBool(_reminder, settings.reminder);
+    await prefs.setString(_time, settings.time);
+  }
+
+  @override
+  Future<void> setReminderTime(String time) async {
+    await prefs.setString(_time, time);
+  }
+}

--- a/toondo/packages/data/lib/repositories/theme_repository_impl.dart
+++ b/toondo/packages/data/lib/repositories/theme_repository_impl.dart
@@ -1,0 +1,28 @@
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:domain/entities/theme_mode_type.dart';
+import 'package:injectable/injectable.dart';
+import 'package:domain/repositories/theme_repository.dart';
+
+@LazySingleton(as: ThemeRepository)
+class ThemeRepositoryImpl implements ThemeRepository {
+  final SharedPreferences prefs;
+  static const _key = 'theme_mode';
+
+  ThemeRepositoryImpl(this.prefs);
+
+
+  @override
+  Future<ThemeModeType> getTheme() async {
+    final saved = prefs.getString(_key);
+    return ThemeModeType.values.firstWhere(
+          (e) => e.name == saved,
+      orElse: () => ThemeModeType.light,
+    );
+  }
+
+  @override
+  Future<void> setTheme(ThemeModeType theme) async {
+    await prefs.setString(_key, theme.name);
+  }
+}
+

--- a/toondo/packages/data/lib/repositories/user_repository_impl.dart
+++ b/toondo/packages/data/lib/repositories/user_repository_impl.dart
@@ -20,12 +20,7 @@ class UserRepositoryImpl implements UserRepository {
     // Calls remote API
     if (newNickName == "test") {
       // Simulate a pass
-      return User(
-        id: 1,
-        nickname: "test",
-        loginId: "1234567890",
-        points: 100
-      );
+      return User(id: 1, nickname: "test", loginId: "1234567890", points: 100);
     }
     final updatedUser = await remoteDatasource.changeNickName(newNickName);
     await localDatasource.setNickName(newNickName);
@@ -42,5 +37,16 @@ class UserRepositoryImpl implements UserRepository {
   @override
   Future<String?> getUserNickname() async {
     return localDatasource.getUserNickname();
+  }
+
+  @override
+  Future<User> getUser() {
+    final model = localDatasource.getUser();
+    if (model != null) {
+      return model;
+    } else {
+      // TODO 서버에서 유저 정보 가져오기 코드 추가해야함 (아래 코드는 삭제)
+      return model;
+    }
   }
 }

--- a/toondo/packages/data/pubspec.lock
+++ b/toondo/packages/data/pubspec.lock
@@ -892,6 +892,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.3"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      sha256: "6e8bf70b7fef813df4e9a36f658ac46d107db4b4cfe1048b477d4e453a8159f5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.3"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: "20cbd561f743a342c76c151d6ddb93a9ce6005751e7aa458baad3858bfbfb6ac"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.10"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "6a52cfcdaeac77cad8c97b539ff688ccfc458c007b4db12be584fbe5c0e49e03"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.4"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   shelf:
     dependency: transitive
     description:
@@ -1163,4 +1219,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.7.0 <4.0.0"
-  flutter: ">=3.24.0"
+  flutter: ">=3.27.0"

--- a/toondo/packages/data/pubspec.yaml
+++ b/toondo/packages/data/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   rive: ^0.13.20
   audioplayers: ^6.1.1
   rxdart: ^0.28.0
+  shared_preferences: ^2.5.3
 
 
 dev_dependencies:

--- a/toondo/packages/data/test/repositories/user_repository_impl_test.mocks.dart
+++ b/toondo/packages/data/test/repositories/user_repository_impl_test.mocks.dart
@@ -8,10 +8,10 @@ import 'dart:async' as _i8;
 import 'package:data/datasources/local/user_local_datasource.dart' as _i6;
 import 'package:data/datasources/remote/user_remote_datasource.dart' as _i9;
 import 'package:data/models/user_model.dart' as _i7;
-import 'package:domain/entities/user.dart' as _i5;
-import 'package:domain/repositories/auth_repository.dart' as _i4;
+import 'package:domain/entities/user.dart' as _i3;
+import 'package:domain/repositories/auth_repository.dart' as _i5;
 import 'package:hive/hive.dart' as _i2;
-import 'package:http/http.dart' as _i3;
+import 'package:http/http.dart' as _i4;
 import 'package:mockito/mockito.dart' as _i1;
 
 // ignore_for_file: type=lint
@@ -38,8 +38,8 @@ class _FakeBox_0<E> extends _i1.SmartFake implements _i2.Box<E> {
         );
 }
 
-class _FakeClient_1 extends _i1.SmartFake implements _i3.Client {
-  _FakeClient_1(
+class _FakeUser_1 extends _i1.SmartFake implements _i3.User {
+  _FakeUser_1(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -48,9 +48,8 @@ class _FakeClient_1 extends _i1.SmartFake implements _i3.Client {
         );
 }
 
-class _FakeAuthRepository_2 extends _i1.SmartFake
-    implements _i4.AuthRepository {
-  _FakeAuthRepository_2(
+class _FakeClient_2 extends _i1.SmartFake implements _i4.Client {
+  _FakeClient_2(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -59,8 +58,9 @@ class _FakeAuthRepository_2 extends _i1.SmartFake
         );
 }
 
-class _FakeUser_3 extends _i1.SmartFake implements _i5.User {
-  _FakeUser_3(
+class _FakeAuthRepository_3 extends _i1.SmartFake
+    implements _i5.AuthRepository {
+  _FakeAuthRepository_3(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -97,7 +97,7 @@ class MockUserLocalDatasource extends _i1.Mock
       );
 
   @override
-  _i8.Future<void> saveUser(_i5.User? user) => (super.noSuchMethod(
+  _i8.Future<void> saveUser(_i3.User? user) => (super.noSuchMethod(
         Invocation.method(
           #saveUser,
           [user],
@@ -114,6 +114,21 @@ class MockUserLocalDatasource extends _i1.Mock
         ),
         returnValue: _i8.Future<String?>.value(),
       ) as _i8.Future<String?>);
+
+  @override
+  _i8.Future<_i3.User> getUser() => (super.noSuchMethod(
+        Invocation.method(
+          #getUser,
+          [],
+        ),
+        returnValue: _i8.Future<_i3.User>.value(_FakeUser_1(
+          this,
+          Invocation.method(
+            #getUser,
+            [],
+          ),
+        )),
+      ) as _i8.Future<_i3.User>);
 
   @override
   _i8.Future<void> updateUserPoints(int? newPoint) => (super.noSuchMethod(
@@ -146,16 +161,16 @@ class MockUserRemoteDatasource extends _i1.Mock
   }
 
   @override
-  _i3.Client get client => (super.noSuchMethod(
+  _i4.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
-        returnValue: _FakeClient_1(
+        returnValue: _FakeClient_2(
           this,
           Invocation.getter(#client),
         ),
-      ) as _i3.Client);
+      ) as _i4.Client);
 
   @override
-  set client(_i3.Client? _client) => super.noSuchMethod(
+  set client(_i4.Client? _client) => super.noSuchMethod(
         Invocation.setter(
           #client,
           _client,
@@ -164,42 +179,42 @@ class MockUserRemoteDatasource extends _i1.Mock
       );
 
   @override
-  _i4.AuthRepository get authRepository => (super.noSuchMethod(
+  _i5.AuthRepository get authRepository => (super.noSuchMethod(
         Invocation.getter(#authRepository),
-        returnValue: _FakeAuthRepository_2(
+        returnValue: _FakeAuthRepository_3(
           this,
           Invocation.getter(#authRepository),
         ),
-      ) as _i4.AuthRepository);
+      ) as _i5.AuthRepository);
 
   @override
-  _i8.Future<_i5.User> changeNickName(String? newNickName) =>
+  _i8.Future<_i3.User> changeNickName(String? newNickName) =>
       (super.noSuchMethod(
         Invocation.method(
           #changeNickName,
           [newNickName],
         ),
-        returnValue: _i8.Future<_i5.User>.value(_FakeUser_3(
+        returnValue: _i8.Future<_i3.User>.value(_FakeUser_1(
           this,
           Invocation.method(
             #changeNickName,
             [newNickName],
           ),
         )),
-      ) as _i8.Future<_i5.User>);
+      ) as _i8.Future<_i3.User>);
 
   @override
-  _i8.Future<_i5.User> updateUserPoints(int? delta) => (super.noSuchMethod(
+  _i8.Future<_i3.User> updateUserPoints(int? delta) => (super.noSuchMethod(
         Invocation.method(
           #updateUserPoints,
           [delta],
         ),
-        returnValue: _i8.Future<_i5.User>.value(_FakeUser_3(
+        returnValue: _i8.Future<_i3.User>.value(_FakeUser_1(
           this,
           Invocation.method(
             #updateUserPoints,
             [delta],
           ),
         )),
-      ) as _i8.Future<_i5.User>);
+      ) as _i8.Future<_i3.User>);
 }

--- a/toondo/packages/domain/lib/entities/notification_settings.dart
+++ b/toondo/packages/domain/lib/entities/notification_settings.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/foundation.dart';
+
+@immutable
+class NotificationSettings {
+  final bool sound;
+  final bool all;
+  final bool report;
+  final bool reminder;
+  final String time;
+
+  const NotificationSettings({
+    required this.sound,
+    required this.all,
+    required this.report,
+    required this.reminder,
+    required this.time,
+  });
+
+  NotificationSettings copyWith({
+    bool? sound,
+    bool? all,
+    bool? report,
+    bool? reminder,
+    String? time,
+  }) {
+    return NotificationSettings(
+      sound: sound ?? this.sound,
+      all: all ?? this.all,
+      report: report ?? this.report,
+      reminder: reminder ?? this.reminder,
+      time: time ?? this.time,
+    );
+  }
+}

--- a/toondo/packages/domain/lib/entities/theme_mode_type.dart
+++ b/toondo/packages/domain/lib/entities/theme_mode_type.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+enum ThemeModeType { light, dark }
+
+extension ThemeModeTypeX on ThemeModeType {
+  ThemeMode toFlutterMode() {
+    switch (this) {
+      case ThemeModeType.light:
+        return ThemeMode.light;
+      case ThemeModeType.dark:
+        return ThemeMode.dark;
+    }
+  }
+
+  static ThemeModeType fromFlutterMode(ThemeMode mode) {
+    return switch (mode) {
+      ThemeMode.light => ThemeModeType.light,
+      ThemeMode.dark => ThemeModeType.dark,
+      _ => ThemeModeType.light, // Default case
+    };
+  }
+}

--- a/toondo/packages/domain/lib/entities/user.dart
+++ b/toondo/packages/domain/lib/entities/user.dart
@@ -2,12 +2,30 @@ class User {
   final int id;
   final String loginId;
   final String? nickname;
-  final int points; // 향후 화폐로 사용
+  final int points;
+  final DateTime createdAt;
 
-  const User({
+  const User._internal({
     required this.id,
     required this.loginId,
     this.nickname,
     required this.points,
+    required this.createdAt,
   });
+
+  factory User({
+    required int id,
+    required String loginId,
+    String? nickname,
+    required int points,
+    DateTime? createdAt,
+  }) {
+    return User._internal(
+      id: id,
+      loginId: loginId,
+      nickname: nickname,
+      points: points,
+      createdAt: createdAt ?? DateTime.now(), // 기본값 처리
+    );
+  }
 }

--- a/toondo/packages/domain/lib/entities/user.dart
+++ b/toondo/packages/domain/lib/entities/user.dart
@@ -2,6 +2,7 @@ class User {
   final int id;
   final String loginId;
   final String? nickname;
+  final String? phoneNumber; // NOTE 현재 서버측 수정이 안되어서 nullable 인데 추후수정
   final int points;
   final DateTime createdAt;
 
@@ -9,6 +10,7 @@ class User {
     required this.id,
     required this.loginId,
     this.nickname,
+    this.phoneNumber,
     required this.points,
     required this.createdAt,
   });
@@ -19,6 +21,7 @@ class User {
     String? nickname,
     required int points,
     DateTime? createdAt,
+    String? phoneNumber,
   }) {
     return User._internal(
       id: id,
@@ -26,6 +29,7 @@ class User {
       nickname: nickname,
       points: points,
       createdAt: createdAt ?? DateTime.now(), // 기본값 처리
+      phoneNumber: phoneNumber,
     );
   }
 }

--- a/toondo/packages/domain/lib/injection/di.config.dart
+++ b/toondo/packages/domain/lib/injection/di.config.dart
@@ -11,6 +11,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:domain/repositories/auth_repository.dart' as _i427;
 import 'package:domain/repositories/goal_repository.dart' as _i559;
+import 'package:domain/repositories/notification_repository.dart' as _i267;
 import 'package:domain/repositories/slime_repository.dart' as _i657;
 import 'package:domain/repositories/sms_repository.dart' as _i366;
 import 'package:domain/repositories/theme_repository.dart' as _i578;
@@ -38,6 +39,11 @@ import 'package:domain/usecases/goal/update_goal_local.dart' as _i1031;
 import 'package:domain/usecases/goal/update_goal_progress.dart' as _i739;
 import 'package:domain/usecases/goal/update_goal_remote.dart' as _i200;
 import 'package:domain/usecases/goal/update_goal_status.dart' as _i856;
+import 'package:domain/usecases/notification/get_notification_settings.dart'
+    as _i22;
+import 'package:domain/usecases/notification/set_notification_settings.dart'
+    as _i930;
+import 'package:domain/usecases/notification/set_reminder_time.dart' as _i236;
 import 'package:domain/usecases/sms/send_sms_code.dart' as _i461;
 import 'package:domain/usecases/sms/verify_sms_code.dart' as _i73;
 import 'package:domain/usecases/theme/get_theme_mode.dart' as _i129;
@@ -79,6 +85,19 @@ extension GetItInjectableX on _i174.GetIt {
     );
     gh.factory<_i969.LogoutUseCase>(
       () => _i969.LogoutUseCase(gh<_i427.AuthRepository>()),
+    );
+    gh.factory<_i22.GetNotificationSettingsUseCase>(
+      () => _i22.GetNotificationSettingsUseCase(
+        gh<_i267.NotificationSettingRepository>(),
+      ),
+    );
+    gh.factory<_i930.SetNotificationSettingsUseCase>(
+      () => _i930.SetNotificationSettingsUseCase(
+        gh<_i267.NotificationSettingRepository>(),
+      ),
+    );
+    gh.factory<_i236.SetReminderTime>(
+      () => _i236.SetReminderTime(gh<_i267.NotificationSettingRepository>()),
     );
     gh.factory<_i129.GetThemeModeUseCase>(
       () => _i129.GetThemeModeUseCase(gh<_i578.ThemeRepository>()),

--- a/toondo/packages/domain/lib/injection/di.config.dart
+++ b/toondo/packages/domain/lib/injection/di.config.dart
@@ -13,6 +13,7 @@ import 'package:domain/repositories/auth_repository.dart' as _i427;
 import 'package:domain/repositories/goal_repository.dart' as _i559;
 import 'package:domain/repositories/slime_repository.dart' as _i657;
 import 'package:domain/repositories/sms_repository.dart' as _i366;
+import 'package:domain/repositories/theme_repository.dart' as _i578;
 import 'package:domain/repositories/todo_repository.dart' as _i158;
 import 'package:domain/repositories/user_repository.dart' as _i988;
 import 'package:domain/usecases/auth/check_phone_number_exists.dart' as _i426;
@@ -39,6 +40,8 @@ import 'package:domain/usecases/goal/update_goal_remote.dart' as _i200;
 import 'package:domain/usecases/goal/update_goal_status.dart' as _i856;
 import 'package:domain/usecases/sms/send_sms_code.dart' as _i461;
 import 'package:domain/usecases/sms/verify_sms_code.dart' as _i73;
+import 'package:domain/usecases/theme/get_theme_mode.dart' as _i129;
+import 'package:domain/usecases/theme/set_theme_mode.dart' as _i366;
 import 'package:domain/usecases/todo/add_todo.dart' as _i133;
 import 'package:domain/usecases/todo/commit_todos.dart' as _i412;
 import 'package:domain/usecases/todo/create_todo.dart' as _i834;
@@ -76,6 +79,12 @@ extension GetItInjectableX on _i174.GetIt {
     );
     gh.factory<_i969.LogoutUseCase>(
       () => _i969.LogoutUseCase(gh<_i427.AuthRepository>()),
+    );
+    gh.factory<_i129.GetThemeModeUseCase>(
+      () => _i129.GetThemeModeUseCase(gh<_i578.ThemeRepository>()),
+    );
+    gh.factory<_i366.SetThemeModeUseCase>(
+      () => _i366.SetThemeModeUseCase(gh<_i578.ThemeRepository>()),
     );
     gh.factory<_i834.CreateTodoUseCase>(
       () => _i834.CreateTodoUseCase(gh<_i158.TodoRepository>()),

--- a/toondo/packages/domain/lib/injection/di.config.dart
+++ b/toondo/packages/domain/lib/injection/di.config.dart
@@ -48,6 +48,7 @@ import 'package:domain/usecases/todo/get_all_todos.dart' as _i362;
 import 'package:domain/usecases/todo/update_todo.dart' as _i375;
 import 'package:domain/usecases/todo/update_todo_dates.dart' as _i182;
 import 'package:domain/usecases/todo/update_todo_status.dart' as _i183;
+import 'package:domain/usecases/user/get_user.dart' as _i991;
 import 'package:domain/usecases/user/get_user_nickname.dart' as _i849;
 import 'package:domain/usecases/user/update_nickname.dart' as _i910;
 import 'package:domain/usecases/user/update_points.dart' as _i1049;
@@ -156,6 +157,9 @@ extension GetItInjectableX on _i174.GetIt {
     );
     gh.factory<_i910.UpdateNickNameUseCase>(
       () => _i910.UpdateNickNameUseCase(gh<_i988.UserRepository>()),
+    );
+    gh.factory<_i991.GetUserUseCase>(
+      () => _i991.GetUserUseCase(gh<_i988.UserRepository>()),
     );
     gh.factory<_i849.GetUserNicknameUseCase>(
       () => _i849.GetUserNicknameUseCase(gh<_i988.UserRepository>()),

--- a/toondo/packages/domain/lib/repositories/notification_repository.dart
+++ b/toondo/packages/domain/lib/repositories/notification_repository.dart
@@ -1,0 +1,7 @@
+import 'package:domain/entities/notification_settings.dart';
+
+abstract class NotificationSettingRepository {
+  Future<NotificationSettings> getSettings();
+  Future<void> setSettings(NotificationSettings settings);
+  Future<void> setReminderTime(String time);
+}

--- a/toondo/packages/domain/lib/repositories/theme_repository.dart
+++ b/toondo/packages/domain/lib/repositories/theme_repository.dart
@@ -1,0 +1,6 @@
+import 'package:domain/entities/theme_mode_type.dart';
+
+abstract class ThemeRepository {
+  Future<void> setTheme(ThemeModeType theme);
+  Future<ThemeModeType> getTheme();
+}

--- a/toondo/packages/domain/lib/repositories/user_repository.dart
+++ b/toondo/packages/domain/lib/repositories/user_repository.dart
@@ -4,5 +4,5 @@ abstract class UserRepository {
   Future<User> updateNickName(String newNickName);
   Future<User> updateUserPoints(int delta);
   Future<String?> getUserNickname();
-  // ...any other methods...
+  Future<User> getUser();
 }

--- a/toondo/packages/domain/lib/usecases/notification/get_notification_settings.dart
+++ b/toondo/packages/domain/lib/usecases/notification/get_notification_settings.dart
@@ -1,0 +1,10 @@
+import 'package:domain/entities/notification_settings.dart';
+import 'package:domain/repositories/notification_repository.dart';
+import 'package:injectable/injectable.dart';
+
+@injectable
+class GetNotificationSettingsUseCase {
+  final NotificationSettingRepository repository;
+  GetNotificationSettingsUseCase(this.repository);
+  Future<NotificationSettings> call() => repository.getSettings();
+}

--- a/toondo/packages/domain/lib/usecases/notification/set_notification_settings.dart
+++ b/toondo/packages/domain/lib/usecases/notification/set_notification_settings.dart
@@ -1,0 +1,10 @@
+import 'package:domain/entities/notification_settings.dart';
+import 'package:domain/repositories/notification_repository.dart';
+import 'package:injectable/injectable.dart';
+
+@injectable
+class SetNotificationSettingsUseCase {
+  final NotificationSettingRepository repository;
+  SetNotificationSettingsUseCase(this.repository);
+  Future<void> call(NotificationSettings settings) => repository.setSettings(settings);
+}

--- a/toondo/packages/domain/lib/usecases/notification/set_reminder_time.dart
+++ b/toondo/packages/domain/lib/usecases/notification/set_reminder_time.dart
@@ -1,0 +1,9 @@
+import 'package:domain/repositories/notification_repository.dart';
+import 'package:injectable/injectable.dart';
+
+@injectable
+class SetReminderTime {
+  final NotificationSettingRepository repository;
+  SetReminderTime(this.repository);
+  Future<void> call(String time) => repository.setReminderTime(time);
+}

--- a/toondo/packages/domain/lib/usecases/theme/get_theme_mode.dart
+++ b/toondo/packages/domain/lib/usecases/theme/get_theme_mode.dart
@@ -1,0 +1,14 @@
+import 'package:domain/entities/theme_mode_type.dart';
+import 'package:domain/repositories/theme_repository.dart';
+import 'package:injectable/injectable.dart';
+
+@injectable
+class GetThemeModeUseCase {
+  final ThemeRepository _themeRepository;
+
+  GetThemeModeUseCase(this._themeRepository);
+
+  Future<ThemeModeType> call() async {
+    return await _themeRepository.getTheme();
+  }
+}

--- a/toondo/packages/domain/lib/usecases/theme/set_theme_mode.dart
+++ b/toondo/packages/domain/lib/usecases/theme/set_theme_mode.dart
@@ -1,0 +1,14 @@
+import 'package:domain/entities/theme_mode_type.dart';
+import 'package:domain/repositories/theme_repository.dart';
+import 'package:injectable/injectable.dart';
+
+@injectable
+class SetThemeModeUseCase {
+  final ThemeRepository _themeRepository;
+
+  SetThemeModeUseCase(this._themeRepository);
+
+  Future<void> call(ThemeModeType themeMode) async {
+    await _themeRepository.setTheme(themeMode);
+  }
+}

--- a/toondo/packages/domain/lib/usecases/user/get_user.dart
+++ b/toondo/packages/domain/lib/usecases/user/get_user.dart
@@ -1,0 +1,13 @@
+import 'package:domain/entities/user.dart';
+import 'package:domain/repositories/user_repository.dart';
+import 'package:injectable/injectable.dart';
+
+@injectable
+class GetUserUseCase {
+  final UserRepository repository;
+  GetUserUseCase(this.repository);
+
+  Future<User> call() async {
+    return repository.getUser();
+  }
+}

--- a/toondo/packages/presentation/lib/injection/di.config.dart
+++ b/toondo/packages/presentation/lib/injection/di.config.dart
@@ -33,6 +33,8 @@ import 'package:domain/usecases/goal/update_goal_remote.dart' as _i200;
 import 'package:domain/usecases/goal/update_goal_status.dart' as _i856;
 import 'package:domain/usecases/sms/send_sms_code.dart' as _i461;
 import 'package:domain/usecases/sms/verify_sms_code.dart' as _i73;
+import 'package:domain/usecases/theme/get_theme_mode.dart' as _i129;
+import 'package:domain/usecases/theme/set_theme_mode.dart' as _i366;
 import 'package:domain/usecases/todo/commit_todos.dart' as _i412;
 import 'package:domain/usecases/todo/create_todo.dart' as _i834;
 import 'package:domain/usecases/todo/delete_todo.dart' as _i552;
@@ -49,12 +51,16 @@ import 'package:injectable/injectable.dart' as _i526;
 import 'package:presentation/viewmodels/character/chat_viewmodel.dart' as _i178;
 import 'package:presentation/viewmodels/character/slime_character_vm.dart'
     as _i88;
+import 'package:presentation/viewmodels/global/app_theme_viewmodel.dart'
+    as _i1040;
 import 'package:presentation/viewmodels/goal/goal_input_viewmodel.dart'
     as _i742;
 import 'package:presentation/viewmodels/goal/goal_management_viewmodel.dart'
     as _i940;
 import 'package:presentation/viewmodels/home/home_viewmodel.dart' as _i370;
 import 'package:presentation/viewmodels/login/login_viewmodel.dart' as _i764;
+import 'package:presentation/viewmodels/my_page/display_setting/display_setting_viewmodel.dart'
+    as _i81;
 import 'package:presentation/viewmodels/my_page/my_page_viewmodel.dart'
     as _i272;
 import 'package:presentation/viewmodels/my_page/notification_setting/time_picker_viewmodel.dart'
@@ -75,6 +81,9 @@ extension GetItInjectableX on _i174.GetIt {
     _i526.EnvironmentFilter? environmentFilter,
   }) {
     final gh = _i526.GetItHelper(this, environment, environmentFilter);
+    gh.factory<_i81.DisplaySettingViewModel>(
+      () => _i81.DisplaySettingViewModel(),
+    );
     gh.lazySingleton<_i393.TimePickerViewModel>(
       () => _i393.TimePickerViewModel(),
     );
@@ -157,6 +166,12 @@ extension GetItInjectableX on _i174.GetIt {
       () => _i370.HomeViewModel(
         gh<_i243.GetInProgressGoalsUseCase>(),
         gh<_i849.GetUserNicknameUseCase>(),
+      ),
+    );
+    gh.lazySingleton<_i1040.AppThemeViewModel>(
+      () => _i1040.AppThemeViewModel(
+        gh<_i129.GetThemeModeUseCase>(),
+        gh<_i366.SetThemeModeUseCase>(),
       ),
     );
     gh.lazySingleton<_i657.OnboardingViewModel>(

--- a/toondo/packages/presentation/lib/injection/di.config.dart
+++ b/toondo/packages/presentation/lib/injection/di.config.dart
@@ -66,6 +66,8 @@ import 'package:presentation/viewmodels/goal/goal_management_viewmodel.dart'
     as _i940;
 import 'package:presentation/viewmodels/home/home_viewmodel.dart' as _i370;
 import 'package:presentation/viewmodels/login/login_viewmodel.dart' as _i764;
+import 'package:presentation/viewmodels/my_page/account_setting/account_setting_viewmodel.dart'
+    as _i501;
 import 'package:presentation/viewmodels/my_page/display_setting/display_setting_viewmodel.dart'
     as _i81;
 import 'package:presentation/viewmodels/my_page/help_guide/help_guide_viewmodel.dart'
@@ -190,6 +192,12 @@ extension GetItInjectableX on _i174.GetIt {
       () => _i370.HomeViewModel(
         gh<_i243.GetInProgressGoalsUseCase>(),
         gh<_i849.GetUserNicknameUseCase>(),
+      ),
+    );
+    gh.factory<_i501.AccountSettingViewModel>(
+      () => _i501.AccountSettingViewModel(
+        getUserUseCase: gh<_i991.GetUserUseCase>(),
+        updateNickNameUseCase: gh<_i910.UpdateNickNameUseCase>(),
       ),
     );
     gh.lazySingleton<_i1040.AppThemeViewModel>(

--- a/toondo/packages/presentation/lib/injection/di.config.dart
+++ b/toondo/packages/presentation/lib/injection/di.config.dart
@@ -11,7 +11,6 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:domain/entities/goal.dart' as _i876;
 import 'package:domain/entities/todo.dart' as _i429;
-import 'package:domain/entities/user.dart' as _i30;
 import 'package:domain/usecases/auth/check_phone_number_exists.dart' as _i426;
 import 'package:domain/usecases/auth/get_token.dart' as _i415;
 import 'package:domain/usecases/auth/login.dart' as _i1068;
@@ -42,6 +41,7 @@ import 'package:domain/usecases/todo/get_all_todos.dart' as _i362;
 import 'package:domain/usecases/todo/update_todo.dart' as _i375;
 import 'package:domain/usecases/todo/update_todo_dates.dart' as _i182;
 import 'package:domain/usecases/todo/update_todo_status.dart' as _i183;
+import 'package:domain/usecases/user/get_user.dart' as _i991;
 import 'package:domain/usecases/user/get_user_nickname.dart' as _i849;
 import 'package:domain/usecases/user/update_nickname.dart' as _i910;
 import 'package:get_it/get_it.dart' as _i174;
@@ -102,9 +102,9 @@ extension GetItInjectableX on _i174.GetIt {
     gh.lazySingleton<_i764.LoginViewModel>(
       () => _i764.LoginViewModel(loginUseCase: gh<_i1068.LoginUseCase>()),
     );
-    gh.lazySingleton<_i272.MyPageViewModel>(
+    gh.factory<_i272.MyPageViewModel>(
       () => _i272.MyPageViewModel(
-        currentUser: gh<_i30.User>(),
+        getUserUseCase: gh<_i991.GetUserUseCase>(),
         commitTodosUseCase: gh<_i412.CommitTodosUseCase>(),
         fetchTodosUseCase: gh<_i314.FetchTodosUseCase>(),
       ),

--- a/toondo/packages/presentation/lib/injection/di.config.dart
+++ b/toondo/packages/presentation/lib/injection/di.config.dart
@@ -68,6 +68,8 @@ import 'package:presentation/viewmodels/home/home_viewmodel.dart' as _i370;
 import 'package:presentation/viewmodels/login/login_viewmodel.dart' as _i764;
 import 'package:presentation/viewmodels/my_page/display_setting/display_setting_viewmodel.dart'
     as _i81;
+import 'package:presentation/viewmodels/my_page/help_guide/help_guide_viewmodel.dart'
+    as _i941;
 import 'package:presentation/viewmodels/my_page/my_page_viewmodel.dart'
     as _i272;
 import 'package:presentation/viewmodels/my_page/notification_setting/notification_setting_viewmodel.dart'
@@ -90,6 +92,7 @@ extension GetItInjectableX on _i174.GetIt {
     _i526.EnvironmentFilter? environmentFilter,
   }) {
     final gh = _i526.GetItHelper(this, environment, environmentFilter);
+    gh.factory<_i941.HelpGuideViewModel>(() => _i941.HelpGuideViewModel());
     gh.factory<_i81.DisplaySettingViewModel>(
       () => _i81.DisplaySettingViewModel(),
     );

--- a/toondo/packages/presentation/lib/injection/di.config.dart
+++ b/toondo/packages/presentation/lib/injection/di.config.dart
@@ -31,6 +31,11 @@ import 'package:domain/usecases/goal/update_goal_local.dart' as _i1031;
 import 'package:domain/usecases/goal/update_goal_progress.dart' as _i739;
 import 'package:domain/usecases/goal/update_goal_remote.dart' as _i200;
 import 'package:domain/usecases/goal/update_goal_status.dart' as _i856;
+import 'package:domain/usecases/notification/get_notification_settings.dart'
+    as _i22;
+import 'package:domain/usecases/notification/set_notification_settings.dart'
+    as _i930;
+import 'package:domain/usecases/notification/set_reminder_time.dart' as _i236;
 import 'package:domain/usecases/sms/send_sms_code.dart' as _i461;
 import 'package:domain/usecases/sms/verify_sms_code.dart' as _i73;
 import 'package:domain/usecases/theme/get_theme_mode.dart' as _i129;
@@ -51,6 +56,8 @@ import 'package:injectable/injectable.dart' as _i526;
 import 'package:presentation/viewmodels/character/chat_viewmodel.dart' as _i178;
 import 'package:presentation/viewmodels/character/slime_character_vm.dart'
     as _i88;
+import 'package:presentation/viewmodels/global/app_notification_viewmodel.dart'
+    as _i370;
 import 'package:presentation/viewmodels/global/app_theme_viewmodel.dart'
     as _i1040;
 import 'package:presentation/viewmodels/goal/goal_input_viewmodel.dart'
@@ -63,6 +70,8 @@ import 'package:presentation/viewmodels/my_page/display_setting/display_setting_
     as _i81;
 import 'package:presentation/viewmodels/my_page/my_page_viewmodel.dart'
     as _i272;
+import 'package:presentation/viewmodels/my_page/notification_setting/notification_setting_viewmodel.dart'
+    as _i942;
 import 'package:presentation/viewmodels/my_page/notification_setting/time_picker_viewmodel.dart'
     as _i393;
 import 'package:presentation/viewmodels/onboarding/onboarding_viewmodel.dart'
@@ -83,9 +92,6 @@ extension GetItInjectableX on _i174.GetIt {
     final gh = _i526.GetItHelper(this, environment, environmentFilter);
     gh.factory<_i81.DisplaySettingViewModel>(
       () => _i81.DisplaySettingViewModel(),
-    );
-    gh.lazySingleton<_i393.TimePickerViewModel>(
-      () => _i393.TimePickerViewModel(),
     );
     gh.lazySingleton<_i197.WelcomeViewModel>(
       () => _i197.WelcomeViewModel(
@@ -141,6 +147,15 @@ extension GetItInjectableX on _i174.GetIt {
         initialDate: gh<DateTime>(),
       ),
     );
+    gh.lazySingleton<_i370.AppNotificationViewModel>(
+      () => _i370.AppNotificationViewModel(
+        gh<_i22.GetNotificationSettingsUseCase>(),
+        gh<_i930.SetNotificationSettingsUseCase>(),
+      ),
+    );
+    gh.factory<_i393.TimePickerViewModel>(
+      () => _i393.TimePickerViewModel(gh<_i236.SetReminderTime>()),
+    );
     gh.lazySingleton<_i742.GoalInputViewModel>(
       () => _i742.GoalInputViewModel(
         createGoalRemoteUseCase: gh<_i343.CreateGoalRemoteUseCase>(),
@@ -148,6 +163,11 @@ extension GetItInjectableX on _i174.GetIt {
         updateGoalRemoteUseCase: gh<_i200.UpdateGoalRemoteUseCase>(),
         updateGoalLocalUseCase: gh<_i1031.UpdateGoalLocalUseCase>(),
         targetGoal: gh<_i876.Goal>(),
+      ),
+    );
+    gh.factory<_i942.NotificationSettingViewModel>(
+      () => _i942.NotificationSettingViewModel(
+        gh<_i370.AppNotificationViewModel>(),
       ),
     );
     gh.lazySingleton<_i705.SignupViewModel>(

--- a/toondo/packages/presentation/lib/injection/di.config.dart
+++ b/toondo/packages/presentation/lib/injection/di.config.dart
@@ -120,13 +120,6 @@ extension GetItInjectableX on _i174.GetIt {
     gh.lazySingleton<_i764.LoginViewModel>(
       () => _i764.LoginViewModel(loginUseCase: gh<_i1068.LoginUseCase>()),
     );
-    gh.factory<_i272.MyPageViewModel>(
-      () => _i272.MyPageViewModel(
-        getUserUseCase: gh<_i991.GetUserUseCase>(),
-        commitTodosUseCase: gh<_i412.CommitTodosUseCase>(),
-        fetchTodosUseCase: gh<_i314.FetchTodosUseCase>(),
-      ),
-    );
     gh.lazySingleton<_i72.TodoInputViewModel>(
       () => _i72.TodoInputViewModel(
         todo: gh<_i429.Todo>(),
@@ -158,6 +151,14 @@ extension GetItInjectableX on _i174.GetIt {
     );
     gh.factory<_i393.TimePickerViewModel>(
       () => _i393.TimePickerViewModel(gh<_i236.SetReminderTime>()),
+    );
+    gh.factory<_i272.MyPageViewModel>(
+      () => _i272.MyPageViewModel(
+        getUserUseCase: gh<_i991.GetUserUseCase>(),
+        commitTodosUseCase: gh<_i412.CommitTodosUseCase>(),
+        fetchTodosUseCase: gh<_i314.FetchTodosUseCase>(),
+        logoutUseCase: gh<_i969.LogoutUseCase>(),
+      ),
     );
     gh.lazySingleton<_i742.GoalInputViewModel>(
       () => _i742.GoalInputViewModel(

--- a/toondo/packages/presentation/lib/models/account_setting_user_ui_model.dart
+++ b/toondo/packages/presentation/lib/models/account_setting_user_ui_model.dart
@@ -1,0 +1,18 @@
+import 'package:domain/entities/user.dart';
+
+class AccountSettingUserUiModel {
+  final String nickname;
+  final String phoneNumber;
+
+  const AccountSettingUserUiModel({
+    required this.nickname,
+    required this.phoneNumber,
+  });
+
+  factory AccountSettingUserUiModel.fromDomain(User user) {
+    return AccountSettingUserUiModel(
+      nickname: user.nickname ?? '익명',
+      phoneNumber: user.phoneNumber ?? '미등록',
+    );
+  }
+}

--- a/toondo/packages/presentation/lib/models/my_page_user_ui_model.dart
+++ b/toondo/packages/presentation/lib/models/my_page_user_ui_model.dart
@@ -1,0 +1,20 @@
+import 'package:domain/entities/user.dart';
+
+class MyPageUserUiModel {
+  final String displayName;
+  final String joinedDaysText;
+
+  const MyPageUserUiModel({
+    required this.displayName,
+    required this.joinedDaysText,
+  });
+
+  factory MyPageUserUiModel.fromDomain(User user) {
+    final displayName = user.nickname ?? user.loginId;
+    final days = DateTime.now().difference(user.createdAt).inDays;
+    return MyPageUserUiModel(
+      displayName: displayName,
+      joinedDaysText: '$days',
+    );
+  }
+}

--- a/toondo/packages/presentation/lib/viewmodels/global/app_notification_viewmodel.dart
+++ b/toondo/packages/presentation/lib/viewmodels/global/app_notification_viewmodel.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:injectable/injectable.dart';
+import 'package:domain/entities/notification_settings.dart';
+import 'package:domain/usecases/notification/get_notification_settings.dart';
+import 'package:domain/usecases/notification/set_notification_settings.dart';
+
+@lazySingleton
+class AppNotificationViewModel extends ChangeNotifier {
+  final GetNotificationSettingsUseCase _get;
+  final SetNotificationSettingsUseCase _set;
+
+  NotificationSettings _settings = const NotificationSettings(
+    sound: true,
+    all: true,
+    report: true,
+    reminder: true,
+    time: '03:00',
+  );
+
+  NotificationSettings get settings => _settings;
+
+  AppNotificationViewModel(this._get, this._set);
+
+  Future<void> load() async {
+    _settings = await _get();
+    notifyListeners();
+  }
+
+  Future<void> update(NotificationSettings newSettings) async {
+    _settings = newSettings;
+    await _set(newSettings);
+    notifyListeners();
+  }
+}

--- a/toondo/packages/presentation/lib/viewmodels/global/app_theme_viewmodel.dart
+++ b/toondo/packages/presentation/lib/viewmodels/global/app_theme_viewmodel.dart
@@ -21,7 +21,6 @@ class AppThemeViewModel extends ChangeNotifier {
 
   Future<void> update(ThemeModeType newMode) async {
     _mode = newMode;
-    print('[AppThemeViewModel] update called with: $newMode'); // 로그 추가
     await setThemeMode(newMode);
     notifyListeners();
   }

--- a/toondo/packages/presentation/lib/viewmodels/global/app_theme_viewmodel.dart
+++ b/toondo/packages/presentation/lib/viewmodels/global/app_theme_viewmodel.dart
@@ -1,0 +1,28 @@
+import 'package:domain/entities/theme_mode_type.dart';
+import 'package:domain/usecases/theme/get_theme_mode.dart';
+import 'package:domain/usecases/theme/set_theme_mode.dart';
+import 'package:flutter/material.dart';
+import 'package:injectable/injectable.dart';
+
+@lazySingleton
+class AppThemeViewModel extends ChangeNotifier {
+  final GetThemeModeUseCase getThemeMode;
+  final SetThemeModeUseCase setThemeMode;
+
+  ThemeModeType _mode = ThemeModeType.light;
+  ThemeModeType get mode => _mode;
+
+  AppThemeViewModel(this.getThemeMode, this.setThemeMode);
+
+  Future<void> load() async {
+    _mode = await getThemeMode();
+    notifyListeners();
+  }
+
+  Future<void> update(ThemeModeType newMode) async {
+    _mode = newMode;
+    print('[AppThemeViewModel] update called with: $newMode'); // 로그 추가
+    await setThemeMode(newMode);
+    notifyListeners();
+  }
+}

--- a/toondo/packages/presentation/lib/viewmodels/my_page/account_setting/account_setting_viewmodel.dart
+++ b/toondo/packages/presentation/lib/viewmodels/my_page/account_setting/account_setting_viewmodel.dart
@@ -1,0 +1,70 @@
+import 'package:domain/usecases/user/get_user.dart';
+import 'package:domain/usecases/user/update_nickname.dart';
+import 'package:flutter/material.dart';
+import 'package:injectable/injectable.dart';
+import 'package:presentation/models/account_setting_user_ui_model.dart';
+
+@injectable
+class AccountSettingViewModel extends ChangeNotifier {
+  final GetUserUseCase getUserUseCase;
+  final UpdateNickNameUseCase updateNickNameUseCase;
+
+  AccountSettingViewModel({
+    required this.getUserUseCase,
+    required this.updateNickNameUseCase,
+  });
+
+  String? _errorMessage;
+  bool _isLoading = false;
+
+  String? get errorMessage => _errorMessage;
+
+  bool get isLoading => _isLoading;
+
+  AccountSettingUserUiModel? _userUiModel;
+
+  AccountSettingUserUiModel? get userUiModel => _userUiModel;
+
+  Future<void> loadUser() async {
+    _isLoading = true;
+    notifyListeners();
+
+    try {
+      final user = await getUserUseCase();
+      _userUiModel = AccountSettingUserUiModel(
+        nickname: user.nickname ?? '', // todo 기본값 추후 수정
+        phoneNumber: user.phoneNumber ?? '010-1234-5678', // todo 기본값 추후 수정
+      );
+      _errorMessage = null;
+    } catch (e) {
+      _errorMessage = '유저 정보를 불러오는 데 실패했습니다.';
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  String? _nicknameErrorMessage;
+
+  String? get nicknameErrorMessage => _nicknameErrorMessage;
+
+  Future<bool> updateNickname(String newNickname) async {
+    if (newNickname.trim().isEmpty) {
+      _nicknameErrorMessage = '신규 닉네임을 입력해주세요';
+      notifyListeners();
+      return false;
+    }
+
+    try {
+      final updatedUser = await updateNickNameUseCase(newNickname);
+      _userUiModel = AccountSettingUserUiModel.fromDomain(updatedUser);
+      _nicknameErrorMessage = null;
+      notifyListeners();
+      return true;
+    } catch (e) {
+      _nicknameErrorMessage = '닉네임 변경에 실패했습니다';
+      notifyListeners();
+      return false;
+    }
+  }
+}

--- a/toondo/packages/presentation/lib/viewmodels/my_page/display_setting/display_setting_viewmodel.dart
+++ b/toondo/packages/presentation/lib/viewmodels/my_page/display_setting/display_setting_viewmodel.dart
@@ -1,0 +1,25 @@
+import 'package:domain/entities/theme_mode_type.dart';
+import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
+import 'package:injectable/injectable.dart';
+import 'package:presentation/viewmodels/global/app_theme_viewmodel.dart';
+
+@injectable
+class DisplaySettingViewModel extends ChangeNotifier {
+  final AppThemeViewModel _themeVM = GetIt.instance<AppThemeViewModel>();
+
+  ThemeModeType? _mode;
+  ThemeModeType get currentMode => _mode!;
+  bool get isLoaded => _mode != null;
+
+  Future<void> load() async {
+    _mode = await _themeVM.getThemeMode();
+    notifyListeners();
+  }
+
+  void selectMode(ThemeModeType mode) {
+    _mode = mode;
+    _themeVM.update(mode);
+    notifyListeners();
+  }
+}

--- a/toondo/packages/presentation/lib/viewmodels/my_page/help_guide/help_guide_viewmodel.dart
+++ b/toondo/packages/presentation/lib/viewmodels/my_page/help_guide/help_guide_viewmodel.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:injectable/injectable.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+@injectable
+class HelpGuideViewModel extends ChangeNotifier {
+  String _version = '';
+  String get appVersion => _version;
+
+  HelpGuideViewModel() {
+    _loadVersion();
+  }
+
+  Future<void> _loadVersion() async {
+    final info = await PackageInfo.fromPlatform();
+    _version = '${info.version} (${info.buildNumber})';
+    notifyListeners();
+  }
+
+  // TODO 구현해야함
+  void openTerms() {}
+  void openAppReview() {}
+  void openPrivacyPolicy() {}
+}

--- a/toondo/packages/presentation/lib/viewmodels/my_page/my_page_viewmodel.dart
+++ b/toondo/packages/presentation/lib/viewmodels/my_page/my_page_viewmodel.dart
@@ -1,22 +1,50 @@
 // lib/viewmodels/my_page/my_page_viewmodel.dart
 
+import 'package:domain/usecases/user/get_user.dart';
 import 'package:flutter/material.dart';
-import 'package:domain/entities/user.dart';
 import 'package:domain/usecases/todo/commit_todos.dart';
 import 'package:domain/usecases/todo/fetch_todos.dart';
 import 'package:injectable/injectable.dart';
+import 'package:presentation/models/my_page_user_ui_model.dart';
 
-@LazySingleton()
+@injectable
 class MyPageViewModel extends ChangeNotifier {
-  final User currentUser;
+  final GetUserUseCase getUserUseCase;
   final CommitTodosUseCase commitTodosUseCase;
   final FetchTodosUseCase fetchTodosUseCase;
 
   MyPageViewModel({
-    required this.currentUser,
+    required this.getUserUseCase,
     required this.commitTodosUseCase,
     required this.fetchTodosUseCase,
   });
+
+  String? _errorMessage;
+  bool _isLoading = false;
+
+  String? get errorMessage => _errorMessage;
+  bool get isLoading => _isLoading;
+
+  MyPageUserUiModel? _userUiModel;
+
+  MyPageUserUiModel? get userUiModel => _userUiModel;
+
+  Future<void> loadUser() async {
+    _isLoading = true;
+    notifyListeners();
+
+    try {
+      final user = await getUserUseCase();
+      _userUiModel = MyPageUserUiModel.fromDomain(user);
+      _errorMessage = null;
+    } catch (e) {
+      _errorMessage = '유저 정보를 불러오는 데 실패했습니다.';
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+
 
   Future<void> fetchTodoOnly() async {
     try {
@@ -38,3 +66,4 @@ class MyPageViewModel extends ChangeNotifier {
     }
   }
 }
+

--- a/toondo/packages/presentation/lib/viewmodels/my_page/my_page_viewmodel.dart
+++ b/toondo/packages/presentation/lib/viewmodels/my_page/my_page_viewmodel.dart
@@ -1,5 +1,6 @@
 // lib/viewmodels/my_page/my_page_viewmodel.dart
 
+import 'package:domain/usecases/auth/logout.dart';
 import 'package:domain/usecases/user/get_user.dart';
 import 'package:flutter/material.dart';
 import 'package:domain/usecases/todo/commit_todos.dart';
@@ -12,11 +13,13 @@ class MyPageViewModel extends ChangeNotifier {
   final GetUserUseCase getUserUseCase;
   final CommitTodosUseCase commitTodosUseCase;
   final FetchTodosUseCase fetchTodosUseCase;
+  final LogoutUseCase logoutUseCase;
 
   MyPageViewModel({
     required this.getUserUseCase,
     required this.commitTodosUseCase,
     required this.fetchTodosUseCase,
+    required this.logoutUseCase,
   });
 
   String? _errorMessage;
@@ -63,6 +66,14 @@ class MyPageViewModel extends ChangeNotifier {
       print('Error committing todo only: $e');
     } finally {
       notifyListeners();
+    }
+  }
+
+  Future<void> logout() async {
+    try {
+      await logoutUseCase();
+    } catch (e) {
+      debugPrint('로그아웃 실패: $e');
     }
   }
 }

--- a/toondo/packages/presentation/lib/viewmodels/my_page/notification_setting/notification_setting_viewmodel.dart
+++ b/toondo/packages/presentation/lib/viewmodels/my_page/notification_setting/notification_setting_viewmodel.dart
@@ -1,0 +1,37 @@
+import 'package:domain/entities/notification_settings.dart';
+import 'package:flutter/material.dart';
+import 'package:injectable/injectable.dart';
+import 'package:presentation/viewmodels/global/app_notification_viewmodel.dart';
+
+@injectable
+class NotificationSettingViewModel extends ChangeNotifier {
+  final AppNotificationViewModel _global;
+  NotificationSettingViewModel(this._global);
+
+  NotificationSettings get settings => _global.settings;
+
+  void toggleSound() {
+    _global.update(settings.copyWith(sound: !settings.sound));
+    notifyListeners();
+  }
+
+  void toggleAll() {
+    _global.update(settings.copyWith(all: !settings.all));
+    notifyListeners();
+  }
+
+  void toggleReport() {
+    _global.update(settings.copyWith(report: !settings.report));
+    notifyListeners();
+  }
+
+  void toggleReminder() {
+    _global.update(settings.copyWith(reminder: !settings.reminder));
+    notifyListeners();
+  }
+
+  void updateTime(String time) {
+    _global.update(settings.copyWith(time: time));
+    notifyListeners();
+  }
+}

--- a/toondo/packages/presentation/lib/viewmodels/my_page/notification_setting/time_picker_viewmodel.dart
+++ b/toondo/packages/presentation/lib/viewmodels/my_page/notification_setting/time_picker_viewmodel.dart
@@ -1,13 +1,34 @@
 import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
 import 'package:injectable/injectable.dart';
+import 'package:domain/usecases/notification/set_reminder_time.dart';
+import 'package:presentation/viewmodels/global/app_notification_viewmodel.dart';
 
-@LazySingleton()
+
+@injectable
 class TimePickerViewModel extends ChangeNotifier {
   String _ampm = '오전';
   String _hour = '08';
   String _minute = '00';
 
+  final SetReminderTime setReminderTimeUseCase;
+
+  TimePickerViewModel(this.setReminderTimeUseCase) {
+    // 초기화 시 현재 글로벌 알림 시간 가져와 파싱
+    final globalTime = GetIt.instance<AppNotificationViewModel>().settings.time;
+    final parts = globalTime.split(RegExp(r'[ :]+'));
+    if (parts.length == 3) {
+      _ampm = parts[0];
+      _hour = parts[1];
+      _minute = parts[2];
+    }
+  }
+
   String get selectedTime => '$_ampm $_hour:$_minute';
+
+  String get ampm => _ampm;
+  String get hour => _hour;
+  String get minute => _minute;
 
   void setAmPm(String value) {
     _ampm = value;
@@ -15,17 +36,22 @@ class TimePickerViewModel extends ChangeNotifier {
   }
 
   void setHour(String value) {
-    _hour = value;
+    _hour = value.padLeft(2, '0');
     notifyListeners();
   }
 
   void setMinute(String value) {
-    _minute = value;
+    _minute = value.padLeft(2, '0');
     notifyListeners();
   }
 
-  void saveSelectedTime() {
-    // TODO: 서버 전송 or 로컬 저장 등
-    debugPrint('저장된 시간: $selectedTime');
+  Future<void> saveSelectedTime() async {
+    final time = selectedTime;
+    await setReminderTimeUseCase(time);
+
+    final global = GetIt.instance<AppNotificationViewModel>();
+    final current = global.settings;
+    global.update(current.copyWith(time: time));
   }
 }
+

--- a/toondo/packages/presentation/lib/views/goal/goal_manage_view.dart
+++ b/toondo/packages/presentation/lib/views/goal/goal_manage_view.dart
@@ -21,7 +21,7 @@ class GoalManageView extends StatelessWidget {
       child: Consumer<GoalManagementViewModel>(
         builder: (context, managementVM, child) {
           return Scaffold(
-            backgroundColor: const Color(0xFFFCFCFC),
+            backgroundColor: Theme.of(context).scaffoldBackgroundColor,
             appBar: CustomAppBar(title: '목표 관리하기'),
             body: SingleChildScrollView(
               child: Padding(

--- a/toondo/packages/presentation/lib/views/mypage/account_setting/account_setting_scaffold.dart
+++ b/toondo/packages/presentation/lib/views/mypage/account_setting/account_setting_scaffold.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+import 'package:presentation/viewmodels/my_page/account_setting/account_setting_viewmodel.dart';
+import 'package:presentation/views/mypage/account_setting/nickname_change_screen.dart';
+import 'package:presentation/views/mypage/account_setting/password_change_screen.dart';
+import 'package:presentation/views/mypage/account_setting/phone_number_change_screen.dart';
+import 'package:presentation/widgets/app_bar/custom_app_bar.dart';
+import 'package:presentation/widgets/my_page/account_setting/account_setting_profile_section.dart';
+import 'package:presentation/widgets/my_page/account_setting/account_setting_tile.dart';
+import 'package:provider/provider.dart';
+
+class AccountSettingScaffold extends StatelessWidget {
+  const AccountSettingScaffold({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final viewModel = context.watch<AccountSettingViewModel>();
+
+    final isLoading = viewModel.isLoading;
+    final user = viewModel.userUiModel;
+
+    return Scaffold(
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+      appBar: const CustomAppBar(title: '계정관리'),
+      body: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 24),
+        child:
+            isLoading
+                ? const Center(child: CircularProgressIndicator())
+                : Column(
+                  children: [
+                    const SizedBox(height: 40),
+                    const AccountSettingProfileSection(),
+                    const SizedBox(height: 40),
+                    AccountSettingTile(
+                      label: '닉네임',
+                      value: user?.nickname ?? '',
+                      onTap: () {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (_) => ChangeNotifierProvider.value(
+                              value: viewModel, // 기존 ViewModel 그대로 전달
+                              child: NicknameChangeScreen(),
+                            ),
+                          ),
+                        );
+                      },
+                    ),
+                    AccountSettingTile(
+                      label: '비밀번호',
+                      value: '변경하기',
+                      onTap: () {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (_) => ChangeNotifierProvider.value(
+                              value: viewModel, // 기존 ViewModel 그대로 전달
+                              child: PasswordChangeScreen(),
+                            ),
+                          ),
+                        );
+                      },
+                    ),
+                    AccountSettingTile(
+                      label: '전화번호',
+                      value: user?.phoneNumber ?? '',
+                      onTap: () {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (_) => ChangeNotifierProvider.value(
+                              value: viewModel, // 기존 ViewModel 그대로 전달
+                              child: PhoneNumberChangeScreen(),
+                            ),
+                          ),
+                        );
+                      },
+                    ),
+                    const AccountSettingTile(label: '계정탈퇴'),
+                  ],
+                ),
+      ),
+    );
+  }
+}

--- a/toondo/packages/presentation/lib/views/mypage/account_setting/account_setting_screen.dart
+++ b/toondo/packages/presentation/lib/views/mypage/account_setting/account_setting_screen.dart
@@ -11,7 +11,7 @@ class AccountSettingScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     // TODO : 하드코딩 된 부분 뷰모델 연결 후 상태로 대체
     return Scaffold(
-      backgroundColor: const Color(0xFFFDFDFD),
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       appBar: const CustomAppBar(title: '계정관리'),
       body: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 24),

--- a/toondo/packages/presentation/lib/views/mypage/account_setting/account_setting_screen.dart
+++ b/toondo/packages/presentation/lib/views/mypage/account_setting/account_setting_screen.dart
@@ -1,59 +1,21 @@
 import 'package:flutter/material.dart';
-import 'package:presentation/navigation/route_paths.dart';
-import 'package:presentation/widgets/app_bar/custom_app_bar.dart';
-import 'package:presentation/widgets/my_page/account_setting/account_setting_profile_section.dart';
-import 'package:presentation/widgets/my_page/account_setting/account_setting_tile.dart';
+import 'package:get_it/get_it.dart';
+import 'package:presentation/viewmodels/my_page/account_setting/account_setting_viewmodel.dart';
+import 'package:presentation/views/mypage/account_setting/account_setting_scaffold.dart';
+import 'package:provider/provider.dart';
 
 class AccountSettingScreen extends StatelessWidget {
   const AccountSettingScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
-    // TODO : 하드코딩 된 부분 뷰모델 연결 후 상태로 대체
-    return Scaffold(
-      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
-      appBar: const CustomAppBar(title: '계정관리'),
-      body: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 24),
-        child: Column(
-          children: [
-            const SizedBox(height: 40),
-            const AccountSettingProfileSection(),
-            const SizedBox(height: 40),
-            AccountSettingTile(
-              label: '닉네임',
-              value: '드리머즈',
-              onTap: () {
-                Navigator.pushNamed(
-                  context,
-                  RoutePaths.accountSettingNicknameChange,
-                );
-              },
-            ),
-            AccountSettingTile(
-              label: '비밀번호',
-              value: 'happyhappy202',
-              onTap: () {
-                Navigator.pushNamed(
-                  context,
-                  RoutePaths.accountSettingPasswordChange,
-                );
-              },
-            ),
-            AccountSettingTile(
-              label: '전화번호',
-              value: '010-0000-0000',
-              onTap: () {
-                Navigator.pushNamed(
-                  context,
-                  RoutePaths.accountSettingPhoneChange,
-                );
-              },
-            ),
-            AccountSettingTile(label: '계정탈퇴'),
-          ],
-        ),
-      ),
+    return ChangeNotifierProvider<AccountSettingViewModel>(
+      create: (_) {
+        final vm = GetIt.instance<AccountSettingViewModel>();
+        vm.loadUser();
+        return vm;
+      },
+      child: const AccountSettingScaffold(),
     );
   }
 }

--- a/toondo/packages/presentation/lib/views/mypage/account_setting/nickname_change_screen.dart
+++ b/toondo/packages/presentation/lib/views/mypage/account_setting/nickname_change_screen.dart
@@ -9,8 +9,8 @@ class NicknameChangeScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(
-      backgroundColor: Color(0xFFFDFDFD),
+    return Scaffold(
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       appBar: CustomAppBar(title: '닉네임 변경'),
       body: Padding(
         padding: EdgeInsets.symmetric(horizontal: 24),

--- a/toondo/packages/presentation/lib/views/mypage/account_setting/nickname_change_screen.dart
+++ b/toondo/packages/presentation/lib/views/mypage/account_setting/nickname_change_screen.dart
@@ -1,32 +1,42 @@
 import 'package:flutter/material.dart';
+import 'package:presentation/viewmodels/my_page/account_setting/account_setting_viewmodel.dart';
 import 'package:presentation/widgets/app_bar/custom_app_bar.dart';
 import 'package:presentation/widgets/my_page/account_setting/account_change_title.dart';
 import 'package:presentation/widgets/my_page/account_setting/nickname_change/nickname_change_button.dart';
 import 'package:presentation/widgets/my_page/account_setting/nickname_change/nickname_change_text_fields.dart';
+import 'package:provider/provider.dart';
 
 class NicknameChangeScreen extends StatelessWidget {
   const NicknameChangeScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
+    final viewModel = context.watch<AccountSettingViewModel>();
+    final nickname = viewModel.userUiModel?.nickname ?? '';
+    final nicknameController = TextEditingController();
+
     return Scaffold(
       backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       appBar: CustomAppBar(title: '닉네임 변경'),
       body: Padding(
-        padding: EdgeInsets.symmetric(horizontal: 24),
+        padding: const EdgeInsets.symmetric(horizontal: 24),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            SizedBox(height: 32),
-            AccountChangeTitle(value: '닉네임'),
-            SizedBox(height: 28),
-            NicknameChangeTextFields(exNickname: '드리머즈'), // TODO : 뷰모델에서 값 받아와야함
-            Spacer(),
-            NicknameChangeButton(),
-            SizedBox(height: 24),
+            const SizedBox(height: 32),
+            const AccountChangeTitle(value: '닉네임'),
+            const SizedBox(height: 28),
+            NicknameChangeTextFields(
+              exNickname: nickname,
+              controller: nicknameController,
+            ),
+            const Spacer(),
+            NicknameChangeButton(controller: nicknameController),
+            const SizedBox(height: 24),
           ],
         ),
       ),
     );
   }
 }
+

--- a/toondo/packages/presentation/lib/views/mypage/account_setting/password_change_screen.dart
+++ b/toondo/packages/presentation/lib/views/mypage/account_setting/password_change_screen.dart
@@ -19,7 +19,7 @@ class PasswordChangeScreen extends StatelessWidget {
     final String? confirmPasswordError = '비밀번호가 일치하지 않습니다.';
 
     return Scaffold(
-      backgroundColor: const Color(0xFFFDFDFD),
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       appBar: const CustomAppBar(title: '비밀번호 변경'),
       body: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 24),

--- a/toondo/packages/presentation/lib/views/mypage/account_setting/phone_number_change_screen.dart
+++ b/toondo/packages/presentation/lib/views/mypage/account_setting/phone_number_change_screen.dart
@@ -17,7 +17,7 @@ class PhoneNumberChangeScreen extends StatelessWidget {
     final codeController = TextEditingController();
 
     return Scaffold(
-      backgroundColor: const Color(0xFFFDFDFD),
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       appBar: const CustomAppBar(title: '전화번호 변경'),
       body: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 24),

--- a/toondo/packages/presentation/lib/views/mypage/display_setting/display_setting_scaffold.dart
+++ b/toondo/packages/presentation/lib/views/mypage/display_setting/display_setting_scaffold.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:presentation/widgets/app_bar/custom_app_bar.dart';
+import 'package:presentation/widgets/my_page/display_setting/display_setting_title_section.dart';
+import 'package:presentation/widgets/my_page/display_setting/theme_mode_option_group.dart';
+
+class DisplaySettingScaffold extends StatelessWidget {
+  const DisplaySettingScaffold({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: const CustomAppBar(title: '화면'),
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+      body: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: const [
+            DisplaySettingTitleSection(),
+            SizedBox(height: 24),
+            ThemeModeOptionGroup(),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/toondo/packages/presentation/lib/views/mypage/display_setting/display_setting_screen.dart
+++ b/toondo/packages/presentation/lib/views/mypage/display_setting/display_setting_screen.dart
@@ -1,27 +1,21 @@
 import 'package:flutter/material.dart';
-import 'package:presentation/widgets/app_bar/custom_app_bar.dart';
-import 'package:presentation/widgets/my_page/display_setting/theme_mode_option_group.dart';
-import 'package:presentation/widgets/my_page/display_setting/display_setting_title_section.dart';
+import 'package:get_it/get_it.dart';
+import 'package:presentation/viewmodels/my_page/display_setting/display_setting_viewmodel.dart';
+import 'package:provider/provider.dart';
+import 'display_setting_scaffold.dart';
 
 class DisplaySettingScreen extends StatelessWidget {
   const DisplaySettingScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: CustomAppBar(title: '화면'),
-      backgroundColor: const Color(0xFFFDFDFD),
-      body: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: const [
-            DisplaySettingTitleSection(),
-            SizedBox(height: 24),
-            ThemeModeOptionGroup(),
-          ],
-        ),
-      ),
+    return ChangeNotifierProvider<DisplaySettingViewModel>(
+      create: (_) {
+        final vm = GetIt.instance<DisplaySettingViewModel>();
+        vm.load();
+        return vm;
+      },
+      child: const DisplaySettingScaffold(),
     );
   }
 }

--- a/toondo/packages/presentation/lib/views/mypage/help_guide/help_guide_scaffold.dart
+++ b/toondo/packages/presentation/lib/views/mypage/help_guide/help_guide_scaffold.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:presentation/viewmodels/my_page/help_guide/help_guide_viewmodel.dart';
+import 'package:presentation/widgets/app_bar/custom_app_bar.dart';
+import 'package:presentation/widgets/my_page/help_guide/help_guide_app_version_tile.dart';
+import 'package:presentation/widgets/my_page/help_guide/help_guide_setting_tile.dart';
+import 'package:provider/provider.dart';
+
+class HelpGuideScaffold extends StatelessWidget {
+  const HelpGuideScaffold({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final vm = context.watch<HelpGuideViewModel>();
+
+    return Scaffold(
+      appBar: const CustomAppBar(title: '이용안내'),
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+      body: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            HelpGuideAppVersionTile(version: vm.appVersion),
+            HelpGuideSettingTile(title: '이용약관', onTap: vm.openTerms),
+            HelpGuideSettingTile(title: '앱 리뷰 남기기', onTap: vm.openAppReview),
+            HelpGuideSettingTile(title: '개인정보 처리방침', onTap: vm.openPrivacyPolicy),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/toondo/packages/presentation/lib/views/mypage/help_guide/help_guide_screen.dart
+++ b/toondo/packages/presentation/lib/views/mypage/help_guide/help_guide_screen.dart
@@ -10,7 +10,7 @@ class HelpGuideScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: const CustomAppBar(title: '이용안내'),
-      backgroundColor: const Color(0xFFFDFDFD),
+        backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       body: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
         child: Column(

--- a/toondo/packages/presentation/lib/views/mypage/help_guide/help_guide_screen.dart
+++ b/toondo/packages/presentation/lib/views/mypage/help_guide/help_guide_screen.dart
@@ -1,28 +1,17 @@
 import 'package:flutter/material.dart';
-import 'package:presentation/widgets/app_bar/custom_app_bar.dart';
-import 'package:presentation/widgets/my_page/help_guide/help_guide_app_version_tile.dart';
-import 'package:presentation/widgets/my_page/help_guide/help_guide_setting_tile.dart';
+import 'package:get_it/get_it.dart';
+import 'package:presentation/viewmodels/my_page/help_guide/help_guide_viewmodel.dart';
+import 'package:provider/provider.dart';
+import 'help_guide_scaffold.dart';
 
 class HelpGuideScreen extends StatelessWidget {
   const HelpGuideScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: const CustomAppBar(title: '이용안내'),
-        backgroundColor: Theme.of(context).scaffoldBackgroundColor,
-      body: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: const [
-            HelpGuideAppVersionTile(),
-            HelpGuideSettingTile(title: '이용약관'),
-            HelpGuideSettingTile(title: '앱 리뷰 남기기'),
-            HelpGuideSettingTile(title: '개인정보 처리방침'),
-          ],
-        ),
-      )
+    return ChangeNotifierProvider(
+      create: (_) => GetIt.instance<HelpGuideViewModel>(),
+      child: const HelpGuideScaffold(),
     );
   }
 }

--- a/toondo/packages/presentation/lib/views/mypage/my_page_scaffold.dart
+++ b/toondo/packages/presentation/lib/views/mypage/my_page_scaffold.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:presentation/viewmodels/my_page/my_page_viewmodel.dart';
+import 'package:presentation/widgets/app_bar/custom_app_bar.dart';
+import 'package:presentation/widgets/my_page/my_page_profile_section.dart';
+import 'package:presentation/widgets/my_page/my_page_setting_section.dart';
+import 'package:provider/provider.dart';
+
+class MyPageScaffold extends StatefulWidget {
+  const MyPageScaffold({super.key});
+
+  @override
+  State<MyPageScaffold> createState() => _MyPageScaffoldState();
+}
+
+class _MyPageScaffoldState extends State<MyPageScaffold> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      context.read<MyPageViewModel>().loadUser();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: const Color(0xFFFDFDFD),
+      appBar: CustomAppBar(title: '마이페이지'),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.symmetric(horizontal: 24),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: const [
+              SizedBox(height: 30),
+              MyPageProfileSection(),
+              SizedBox(height: 32),
+              Divider(color: Color(0xFFDADADA), height: 1),
+              SizedBox(height: 32),
+              MyPageSettingSection(),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/toondo/packages/presentation/lib/views/mypage/my_page_scaffold.dart
+++ b/toondo/packages/presentation/lib/views/mypage/my_page_scaffold.dart
@@ -24,7 +24,7 @@ class _MyPageScaffoldState extends State<MyPageScaffold> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: const Color(0xFFFDFDFD),
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       appBar: CustomAppBar(title: '마이페이지'),
       body: SafeArea(
         child: SingleChildScrollView(

--- a/toondo/packages/presentation/lib/views/mypage/my_page_screen.dart
+++ b/toondo/packages/presentation/lib/views/mypage/my_page_screen.dart
@@ -1,32 +1,17 @@
 import 'package:flutter/material.dart';
-import 'package:presentation/widgets/app_bar/custom_app_bar.dart';
-import 'package:presentation/widgets/my_page/my_page_profile_section.dart';
-import 'package:presentation/widgets/my_page/my_page_setting_section.dart';
+import 'package:provider/provider.dart';
+import 'package:get_it/get_it.dart';
+import 'package:presentation/viewmodels/my_page/my_page_viewmodel.dart';
+import 'my_page_scaffold.dart';
 
 class MyPageScreen extends StatelessWidget {
   const MyPageScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: const Color(0xFFFDFDFD),
-      appBar: CustomAppBar(title: '마이페이지'),
-      body: SafeArea(
-        child: SingleChildScrollView(
-          padding: const EdgeInsets.symmetric(horizontal: 24),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: const [
-              SizedBox(height: 30),
-              MyPageProfileSection(),
-              SizedBox(height: 32),
-              Divider(color: Color(0xFFDADADA), height: 1),
-              SizedBox(height: 32),
-              MyPageSettingSection(),
-            ],
-          ),
-        ),
-      ),
+    return ChangeNotifierProvider<MyPageViewModel>(
+      create: (_) => GetIt.instance<MyPageViewModel>(),
+      child: const MyPageScaffold(),
     );
   }
 }

--- a/toondo/packages/presentation/lib/views/mypage/notification_setting/notification_setting_scaffold.dart
+++ b/toondo/packages/presentation/lib/views/mypage/notification_setting/notification_setting_scaffold.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:presentation/viewmodels/my_page/notification_setting/notification_setting_viewmodel.dart';
+import 'package:presentation/widgets/app_bar/custom_app_bar.dart';
+import 'package:presentation/widgets/my_page/notification_setting/notification_time_tile.dart';
+import 'package:presentation/widgets/my_page/notification_setting/notification_tip_text.dart';
+import 'package:presentation/widgets/my_page/notification_setting/notification_toggle_tile.dart';
+import 'package:provider/provider.dart';
+
+class NotificationSettingScaffold extends StatelessWidget {
+  const NotificationSettingScaffold({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final vm = context.watch<NotificationSettingViewModel>();
+
+    return Scaffold(
+      appBar: CustomAppBar(title: '알림 설정'),
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+      body: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            NotificationToggleTile(
+              title: '효과음',
+              value: vm.settings.sound,
+              onChanged: (_) => vm.toggleSound(),
+            ),
+            NotificationToggleTile(
+              title: '전체알림',
+              value: vm.settings.all,
+              onChanged: (_) => vm.toggleAll(),
+            ),
+            NotificationToggleTile(
+              title: '분석리포트 알림',
+              value: vm.settings.report,
+              onChanged: (_) => vm.toggleReport(),
+            ),
+            NotificationToggleTile(
+              title: '리마인드 알림',
+              value: vm.settings.reminder,
+              onChanged: (_) => vm.toggleReminder(),
+            ),
+            const SizedBox(height: 24),
+            NotificationTimeTile(),
+            const SizedBox(height: 24),
+            const NotificationTipText(),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/toondo/packages/presentation/lib/views/mypage/notification_setting/notification_setting_screen.dart
+++ b/toondo/packages/presentation/lib/views/mypage/notification_setting/notification_setting_screen.dart
@@ -1,33 +1,17 @@
 import 'package:flutter/material.dart';
-import 'package:presentation/widgets/app_bar/custom_app_bar.dart';
-import 'package:presentation/widgets/my_page/notification_setting/notification_time_tile.dart';
-import 'package:presentation/widgets/my_page/notification_setting/notification_tip_text.dart';
-import 'package:presentation/widgets/my_page/notification_setting/notification_toggle_tile.dart';
+import 'package:get_it/get_it.dart';
+import 'package:presentation/viewmodels/my_page/notification_setting/notification_setting_viewmodel.dart';
+import 'package:provider/provider.dart';
+import 'notification_setting_scaffold.dart';
 
 class NotificationSettingScreen extends StatelessWidget {
   const NotificationSettingScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: CustomAppBar(title: '알림 설정'),
-      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
-      body: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            const NotificationToggleTile(title: '효과음', value: false),
-            const NotificationToggleTile(title: '전체알림', value: true),
-            const NotificationToggleTile(title: '분석리포트 알림', value: true),
-            const NotificationToggleTile(title: '리마인드 알림', value: true),
-            const SizedBox(height: 24),
-            const NotificationTimeTile(timeText: '03:00'),
-            const SizedBox(height: 24),
-            const NotificationTipText(),
-          ],
-        ),
-      ),
+    return ChangeNotifierProvider(
+      create: (_) => GetIt.instance<NotificationSettingViewModel>(),
+      child: const NotificationSettingScaffold(),
     );
   }
 }

--- a/toondo/packages/presentation/lib/views/mypage/notification_setting/notification_setting_screen.dart
+++ b/toondo/packages/presentation/lib/views/mypage/notification_setting/notification_setting_screen.dart
@@ -11,7 +11,7 @@ class NotificationSettingScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: CustomAppBar(title: '알림 설정'),
-      backgroundColor: const Color(0xFFFDFDFD),
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       body: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
         child: Column(

--- a/toondo/packages/presentation/lib/views/todo/todo_manage_view.dart
+++ b/toondo/packages/presentation/lib/views/todo/todo_manage_view.dart
@@ -35,7 +35,7 @@ class TodoManageView extends StatelessWidget {
             initialDate: selectedDate,
           )..loadTodos(),
       child: Scaffold(
-        backgroundColor: Colors.white,
+        backgroundColor: Theme.of(context).scaffoldBackgroundColor,
         appBar: CustomAppBar(title: '투두리스트'),
         body: Consumer<TodoManageViewModel>(
           builder: (context, viewModel, child) {

--- a/toondo/packages/presentation/lib/widgets/app_bar/custom_app_bar.dart
+++ b/toondo/packages/presentation/lib/widgets/app_bar/custom_app_bar.dart
@@ -7,13 +7,15 @@ class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
 
   @override
   Widget build(BuildContext context) {
+    final textColor = Theme.of(context).textTheme.bodyMedium?.color;
+
     return AppBar(
-      backgroundColor: const Color(0xFFFCFCFC),
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       elevation: 0,
       leading: Padding(
         padding: const EdgeInsets.only(left: 16),
         child: IconButton(
-          icon: const Icon(Icons.arrow_back_ios, color: Color(0xFF1C1D1B)),
+          icon: Icon(Icons.arrow_back_ios, color: IconTheme.of(context).color),
           onPressed: () {
             Navigator.pop(context);
           },
@@ -23,11 +25,11 @@ class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
       titleSpacing: 1.0,
       title: Text(
         title,
-        style: const TextStyle(
-          color: Color(0xFF1C1D1B),
-          fontSize: 16,
+        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
           fontWeight: FontWeight.w400,
           letterSpacing: 0.24,
+          fontSize: 16,
+          color: textColor,
           fontFamily: 'Pretendard Variable',
         ),
       ),

--- a/toondo/packages/presentation/lib/widgets/home/home_app_bar.dart
+++ b/toondo/packages/presentation/lib/widgets/home/home_app_bar.dart
@@ -9,7 +9,7 @@ class HomeAppBar extends StatelessWidget implements PreferredSizeWidget {
   @override
   Widget build(BuildContext context) {
     return AppBar(
-      backgroundColor: Colors.white,
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       elevation: 0,
       centerTitle: true,
       title: const Text(

--- a/toondo/packages/presentation/lib/widgets/my_page/account_setting/account_change_text_field.dart
+++ b/toondo/packages/presentation/lib/widgets/my_page/account_setting/account_change_text_field.dart
@@ -4,10 +4,12 @@ class AccountChangeTextField extends StatelessWidget {
   final String label;
   final String? hintText;
   final TextEditingController? controller;
+
   final TextInputType keyboardType;
   final bool obscureText;
   final bool enabled;
   final String? initialValue;
+  final String? errorText;
 
   const AccountChangeTextField({
     super.key,
@@ -18,6 +20,7 @@ class AccountChangeTextField extends StatelessWidget {
     this.keyboardType = TextInputType.text,
     this.obscureText = false,
     this.initialValue,
+    this.errorText,
   });
 
   @override
@@ -33,6 +36,7 @@ class AccountChangeTextField extends StatelessWidget {
           obscureText: obscureText,
           enabled: enabled,
           initialValue: initialValue,
+          errorText: errorText,
         ),
       ],
     );
@@ -69,6 +73,7 @@ class _RoundedTextField extends StatelessWidget {
   final TextEditingController? controller;
   final TextInputType keyboardType;
   final bool obscureText;
+  final String? errorText;
 
   const _RoundedTextField({
     this.hintText,
@@ -77,6 +82,7 @@ class _RoundedTextField extends StatelessWidget {
     this.controller,
     this.keyboardType = TextInputType.text,
     this.obscureText = false,
+    this.errorText,
   });
 
   @override
@@ -90,6 +96,7 @@ class _RoundedTextField extends StatelessWidget {
       obscureText: obscureText,
       decoration: InputDecoration(
         hintText: hintText,
+        errorText: errorText,
         contentPadding: const EdgeInsets.symmetric(horizontal: 16),
         filled: true,
         fillColor: Colors.white,

--- a/toondo/packages/presentation/lib/widgets/my_page/account_setting/account_change_text_field.dart
+++ b/toondo/packages/presentation/lib/widgets/my_page/account_setting/account_change_text_field.dart
@@ -46,18 +46,18 @@ class _LabelText extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final textColor = Theme.of(context).textTheme.bodyMedium?.color;
     return Align(
       alignment: Alignment.centerLeft,
       child: Text(
         label,
-        style: const TextStyle(
-          fontSize: 12,
-          color: Color(0xFF1C1D1B),
+        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
           fontWeight: FontWeight.w400,
+          fontSize: 12,
+          color: textColor,
           fontFamily: 'Pretendard Variable',
-          letterSpacing: 1.5,
-        ),
       ),
+    ),
     );
   }
 }

--- a/toondo/packages/presentation/lib/widgets/my_page/account_setting/account_change_title.dart
+++ b/toondo/packages/presentation/lib/widgets/my_page/account_setting/account_change_title.dart
@@ -19,16 +19,16 @@ class AccountChangeTitle extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final textColor = Theme.of(context).textTheme.bodyMedium?.color;
     final postPosition = _getPostPosition(value);
 
     return Text(
       '$value$postPosition 입력해주세요',
-      style: const TextStyle(
-        fontSize: 16,
-        fontWeight: FontWeight.w700,
-        color: Color(0xFF78B545),
+      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+        fontWeight: FontWeight.w400,
+        fontSize: 14,
+        color: textColor,
         fontFamily: 'Pretendard Variable',
-        letterSpacing: 1.5,
       ),
     );
   }

--- a/toondo/packages/presentation/lib/widgets/my_page/account_setting/account_password_field.dart
+++ b/toondo/packages/presentation/lib/widgets/my_page/account_setting/account_password_field.dart
@@ -23,6 +23,9 @@ class _AccountPasswordFieldState extends State<AccountPasswordField> {
 
   @override
   Widget build(BuildContext context) {
+    final textColor = widget.errorText != null
+        ? Colors.red
+        : Theme.of(context).textTheme.bodyMedium?.color;
     final borderColor =
     widget.errorText != null ? Colors.red : const Color(0xFFDDDDDD);
 
@@ -31,10 +34,10 @@ class _AccountPasswordFieldState extends State<AccountPasswordField> {
       children: [
         Text(
           widget.label,
-          style: const TextStyle(
-            fontSize: 12,
-            color: Color(0xFF1C1D1B),
+          style: Theme.of(context).textTheme.bodyMedium?.copyWith(
             fontWeight: FontWeight.w400,
+            fontSize: 12,
+            color: textColor,
             fontFamily: 'Pretendard Variable',
           ),
         ),

--- a/toondo/packages/presentation/lib/widgets/my_page/account_setting/account_setting_tile.dart
+++ b/toondo/packages/presentation/lib/widgets/my_page/account_setting/account_setting_tile.dart
@@ -9,6 +9,8 @@ class AccountSettingTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final textColor = Theme.of(context).textTheme.bodyMedium?.color;
+
     return InkWell(
       onTap: onTap,
       borderRadius: BorderRadius.circular(8),
@@ -20,10 +22,11 @@ class AccountSettingTile extends StatelessWidget {
           children: [
             Text(
               label,
-              style: const TextStyle(
-                fontSize: 14,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                 fontWeight: FontWeight.w400,
-                color: Color(0xFF1C1D1B),
+                fontSize: 14,
+                color: textColor,
+                fontFamily: 'Pretendard Variable',
               ),
             ),
             Row(
@@ -31,10 +34,11 @@ class AccountSettingTile extends StatelessWidget {
                 if (value != null)
                   Text(
                     value!,
-                    style: const TextStyle(
-                      fontSize: 14,
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                       fontWeight: FontWeight.w400,
-                      color: Color(0xff858584),
+                      fontSize: 14,
+                      color: textColor,
+                      fontFamily: 'Pretendard Variable',
                     ),
                   ),
                 const SizedBox(width: 16),

--- a/toondo/packages/presentation/lib/widgets/my_page/account_setting/nickname_change/nickname_change_button.dart
+++ b/toondo/packages/presentation/lib/widgets/my_page/account_setting/nickname_change/nickname_change_button.dart
@@ -1,15 +1,33 @@
 import 'package:flutter/material.dart';
+import 'package:presentation/viewmodels/my_page/account_setting/account_setting_viewmodel.dart';
 import 'package:presentation/widgets/bottom_button/green_button.dart';
+import 'package:provider/provider.dart';
 
-class NicknameChangeButton extends GreenButton {
-  const NicknameChangeButton({
-    super.key,
-    super.title = '변경하기',
-    super.onPressed = _defaultAction,
-  });
+class NicknameChangeButton extends StatelessWidget {
+  final TextEditingController controller;
 
-  static void _defaultAction() {
-    // TODO: ViewModel과 연결 후 교체
-    debugPrint('[닉네임 변경] 버튼 눌림 - 구현 예정');
+  const NicknameChangeButton({super.key, required this.controller});
+
+  @override
+  Widget build(BuildContext context) {
+    final viewModel = context.read<AccountSettingViewModel>();
+
+    return ElevatedButton(
+      style: ElevatedButton.styleFrom(
+        minimumSize: const Size(double.infinity, 56),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(32),
+        ),
+        backgroundColor: const Color(0xFF76B852),
+      ),
+      onPressed: () async {
+        final success = await viewModel.updateNickname(controller.text);
+        if (success && context.mounted) {
+          Navigator.pop(context);
+        }
+      },
+      child: const Text('변경하기'),
+    );
   }
 }
+

--- a/toondo/packages/presentation/lib/widgets/my_page/account_setting/nickname_change/nickname_change_text_fields.dart
+++ b/toondo/packages/presentation/lib/widgets/my_page/account_setting/nickname_change/nickname_change_text_fields.dart
@@ -1,13 +1,22 @@
 import 'package:flutter/material.dart';
+import 'package:presentation/viewmodels/my_page/account_setting/account_setting_viewmodel.dart';
 import 'package:presentation/widgets/my_page/account_setting/account_change_text_field.dart';
+import 'package:provider/provider.dart';
 
 class NicknameChangeTextFields extends StatelessWidget {
+  final TextEditingController controller;
   final String exNickname;
 
-  const NicknameChangeTextFields({super.key, required this.exNickname});
+  const NicknameChangeTextFields({
+    super.key,
+    required this.exNickname,
+    required this.controller,
+  });
 
   @override
   Widget build(BuildContext context) {
+    final error = context.watch<AccountSettingViewModel>().nicknameErrorMessage;
+
     return Column(
       children: [
         AccountChangeTextField(
@@ -18,10 +27,12 @@ class NicknameChangeTextFields extends StatelessWidget {
         const SizedBox(height: 24),
         AccountChangeTextField(
           label: '신규 닉네임',
-          controller: TextEditingController(),
+          controller: controller,
           keyboardType: TextInputType.text,
+          errorText: error,
         ),
       ],
     );
   }
 }
+

--- a/toondo/packages/presentation/lib/widgets/my_page/display_setting/display_setting_title_section.dart
+++ b/toondo/packages/presentation/lib/widgets/my_page/display_setting/display_setting_title_section.dart
@@ -5,12 +5,14 @@ class DisplaySettingTitleSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final textColor = Theme.of(context).textTheme.bodyMedium?.color;
+
     return Text(
       '다크모드 설정',
-      style: TextStyle(
-        fontSize: 14,
+      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
         fontWeight: FontWeight.w600,
-        color: Color(0xFF1C1D1B),
+        fontSize: 14,
+        color: textColor,
         fontFamily: 'Pretendard Variable',
       ),
     );

--- a/toondo/packages/presentation/lib/widgets/my_page/display_setting/theme_mode_option_group.dart
+++ b/toondo/packages/presentation/lib/widgets/my_page/display_setting/theme_mode_option_group.dart
@@ -1,22 +1,39 @@
+import 'package:domain/entities/theme_mode_type.dart';
 import 'package:flutter/material.dart';
+import 'package:presentation/viewmodels/my_page/display_setting/display_setting_viewmodel.dart';
 import 'package:presentation/widgets/my_page/display_setting/theme_mode_option_tile.dart';
+import 'package:provider/provider.dart';
 
 class ThemeModeOptionGroup extends StatelessWidget {
   const ThemeModeOptionGroup({super.key});
 
   @override
   Widget build(BuildContext context) {
+    final vm = context.watch<DisplaySettingViewModel>();
+
+    if (!vm.isLoaded) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    final selectedMode = vm.currentMode;
+
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-      children: const [
-        ThemeModeOptionTile(
-          mode: ThemeMode.light,
-          selected: true,
+      children: [
+        GestureDetector(
+          onTap: () => vm.selectMode(ThemeModeType.light),
+          child: ThemeModeOptionTile(
+            mode: ThemeModeType.light,
+            selected: selectedMode == ThemeModeType.light,
+          ),
         ),
-        SizedBox(width: 8),
-        ThemeModeOptionTile(
-          mode: ThemeMode.dark,
-          selected: false,
+        const SizedBox(width: 8),
+        GestureDetector(
+          onTap: () => vm.selectMode(ThemeModeType.dark),
+          child: ThemeModeOptionTile(
+            mode: ThemeModeType.dark,
+            selected: selectedMode == ThemeModeType.dark,
+          ),
         ),
       ],
     );

--- a/toondo/packages/presentation/lib/widgets/my_page/display_setting/theme_mode_option_tile.dart
+++ b/toondo/packages/presentation/lib/widgets/my_page/display_setting/theme_mode_option_tile.dart
@@ -1,9 +1,10 @@
+import 'package:common/gen/assets.gen.dart';
+import 'package:domain/entities/theme_mode_type.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 import 'theme_mode_indicator.dart';
 
 class ThemeModeOptionTile extends StatelessWidget {
-  final ThemeMode mode;
+  final ThemeModeType mode;
   final bool selected;
 
   const ThemeModeOptionTile({
@@ -14,51 +15,92 @@ class ThemeModeOptionTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final isLight = mode == ThemeMode.light;
+    final textColor = Theme.of(context).textTheme.bodyMedium?.color;
+    final isLight = mode == ThemeModeType.light;
 
-    final backgroundColor = isLight
-        ? const Color(0xFFFDFDFD)
-        : const Color(0xFF444444);
+    final backgroundColor =
+        isLight ? const Color(0xFFFDFDFD) : const Color(0xFF444444);
 
-    final borderColor = isLight
-        ? (selected ? const Color(0xFF78B545) : const Color(0xFFD9D9D9))
-        : Colors.transparent;
+    final borderColor =
+        selected
+            ? const Color(0xFF78B545)
+            : (isLight ? const Color(0xFFD9D9D9) : Colors.transparent);
 
-    final iconColor = isLight
-        ? const Color(0x801C1D1B)
-        : const Color(0xA6FFFFFF);
+    final iconColor =
+        isLight ? const Color(0x801C1D1B) : const Color(0xA6FFFFFF);
 
     return Column(
       children: [
-        Container(
-          width: 145,
-          height: 96,
-          decoration: BoxDecoration(
-            color: backgroundColor,
-            borderRadius: BorderRadius.circular(16),
-            border: Border.all(color: borderColor, width: 2.0),
-          ),
-          child: Center(
-            child: SvgPicture.asset(
-              'assets/icons/ic_face_0.svg',
-              width: 40,
-              height: 40,
-              colorFilter: ColorFilter.mode(iconColor, BlendMode.srcIn),
+        selected
+            ? Container(
+              width: 145,
+              height: 96,
+              padding: const EdgeInsets.all(2),
+              // border color
+              decoration: BoxDecoration(
+                color: const Color(0xFF78B545),
+                borderRadius: BorderRadius.circular(16),
+              ),
+              child: _InnerBox(isLight: isLight, iconColor: iconColor),
+            )
+            : Container(
+              width: 145,
+              height: 96,
+              decoration: BoxDecoration(
+                color: backgroundColor,
+                borderRadius: BorderRadius.circular(16),
+                border:
+                    isLight
+                        ? Border.all(color: const Color(0xFFD9D9D9), width: 2)
+                        : null,
+              ),
+              child: Center(
+                child: Assets.icons.icFace0.svg(
+                  width: 40,
+                  height: 40,
+                  colorFilter: ColorFilter.mode(iconColor, BlendMode.srcIn),
+                ),
+              ),
             ),
-          ),
-        ),
         const SizedBox(height: 8),
         Text(
           isLight ? '라이트' : '다크',
-          style: const TextStyle(
-            fontSize: 12,
+          style: Theme.of(context).textTheme.bodyMedium?.copyWith(
             fontWeight: FontWeight.w400,
-            color: Color(0xFF1C1D1B),
+            fontSize: 14,
+            color: textColor,
           ),
         ),
         const SizedBox(height: 8),
         ThemeModeIndicator(isSelected: selected),
       ],
+    );
+  }
+}
+
+class _InnerBox extends StatelessWidget {
+  final bool isLight;
+  final Color iconColor;
+
+  const _InnerBox({required this.isLight, required this.iconColor});
+
+  @override
+  Widget build(BuildContext context) {
+    final backgroundColor =
+        isLight ? const Color(0xFFFDFDFD) : const Color(0xFF444444);
+
+    return Container(
+      decoration: BoxDecoration(
+        color: backgroundColor,
+        borderRadius: BorderRadius.circular(14),
+      ),
+      child: Center(
+        child: Assets.icons.icFace0.svg(
+          width: 40,
+          height: 40,
+          colorFilter: ColorFilter.mode(iconColor, BlendMode.srcIn),
+        ),
+      ),
     );
   }
 }

--- a/toondo/packages/presentation/lib/widgets/my_page/help_guide/help_guide_app_version_tile.dart
+++ b/toondo/packages/presentation/lib/widgets/my_page/help_guide/help_guide_app_version_tile.dart
@@ -5,28 +5,30 @@ class HelpGuideAppVersionTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final textColor = Theme.of(context).textTheme.bodyMedium?.color;
+
     return Container(
       height: 52,
       padding: const EdgeInsets.symmetric(vertical: 14),
-      color: const Color(0xFFFCFCFC),
-      child: const Row(
+      color: Colors.transparent,
+      child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
           Text(
             '앱 버전',
-            style: TextStyle(
-              color: Color(0xFF1C1D1B),
-              fontSize: 14,
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
               fontWeight: FontWeight.w400,
+              fontSize: 14,
+              color: textColor,
               fontFamily: 'Pretendard Variable',
             ),
           ),
           Text(
             '1.0.1',
-            style: TextStyle(
-              color: Color(0xff858584),
-              fontSize: 14,
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
               fontWeight: FontWeight.w400,
+              fontSize: 14,
+              color: textColor,
               fontFamily: 'Pretendard Variable',
             ),
           ),

--- a/toondo/packages/presentation/lib/widgets/my_page/help_guide/help_guide_app_version_tile.dart
+++ b/toondo/packages/presentation/lib/widgets/my_page/help_guide/help_guide_app_version_tile.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 
 class HelpGuideAppVersionTile extends StatelessWidget {
-  const HelpGuideAppVersionTile({super.key});
+  final String version;
+
+  const HelpGuideAppVersionTile({super.key, required this.version});
 
   @override
   Widget build(BuildContext context) {
@@ -24,7 +26,7 @@ class HelpGuideAppVersionTile extends StatelessWidget {
             ),
           ),
           Text(
-            '1.0.1',
+            version,
             style: Theme.of(context).textTheme.bodyMedium?.copyWith(
               fontWeight: FontWeight.w400,
               fontSize: 14,

--- a/toondo/packages/presentation/lib/widgets/my_page/help_guide/help_guide_setting_tile.dart
+++ b/toondo/packages/presentation/lib/widgets/my_page/help_guide/help_guide_setting_tile.dart
@@ -8,28 +8,30 @@ class HelpGuideSettingTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final textColor = Theme.of(context).textTheme.bodyMedium?.color;
+
     return InkWell(
       onTap: onTap, // TODO: 라우팅 추가 예정
       child: Container(
         height: 52,
         padding: const EdgeInsets.symmetric(vertical: 14),
-        color: const Color(0xFFFCFCFC),
+        color: Colors.transparent,
         child: Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
             Text(
               title,
-              style: const TextStyle(
-                color: Color(0xFF1C1D1B),
-                fontSize: 14,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                 fontWeight: FontWeight.w400,
+                fontSize: 14,
+                color: textColor,
                 fontFamily: 'Pretendard Variable',
               ),
             ),
-            const Icon(
+            Icon(
               Icons.arrow_forward_ios,
               size: 16,
-              color: Color(0xFFD9D9D9),
+              color: IconTheme.of(context).color,
             ),
           ],
         ),

--- a/toondo/packages/presentation/lib/widgets/my_page/my_page_profile_section.dart
+++ b/toondo/packages/presentation/lib/widgets/my_page/my_page_profile_section.dart
@@ -1,12 +1,16 @@
-import 'package:common/gen/assets.gen.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_svg/svg.dart';
+import 'package:provider/provider.dart';
+import 'package:presentation/viewmodels/my_page/my_page_viewmodel.dart';
+import 'package:common/gen/assets.gen.dart';
 
 class MyPageProfileSection extends StatelessWidget {
   const MyPageProfileSection({super.key});
 
   @override
   Widget build(BuildContext context) {
+    final vm = context.watch<MyPageViewModel>();
+    final userUiModel = vm.userUiModel;
+
     return Row(
       crossAxisAlignment: CrossAxisAlignment.center,
       children: [
@@ -50,24 +54,24 @@ class MyPageProfileSection extends StatelessWidget {
         Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            const Text(
-              '드리머즈',
-              style: TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
+            Text(
+              userUiModel?.displayName ?? '',
+              style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
             ),
             const SizedBox(height: 4),
             Text.rich(
               TextSpan(
-                children: const [
-                  TextSpan(
+                children: [
+                  const TextSpan(
                     text: 'ToonDo',
                     style: TextStyle(fontSize: 10, fontWeight: FontWeight.w600),
                   ),
-                  TextSpan(text: '와 함께한 지 '),
+                  const TextSpan(text: '와 함께한 지 '),
                   TextSpan(
-                    text: '21',
-                    style: TextStyle(color: Color(0xFF78B545)),
+                    text: userUiModel?.joinedDaysText ?? '0',
+                    style: const TextStyle(color: Color(0xFF78B545)),
                   ),
-                  TextSpan(text: '일째'),
+                  const TextSpan(text: '일째'),
                 ],
               ),
               style: const TextStyle(fontSize: 10),

--- a/toondo/packages/presentation/lib/widgets/my_page/my_page_setting_section.dart
+++ b/toondo/packages/presentation/lib/widgets/my_page/my_page_setting_section.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:presentation/navigation/route_paths.dart';
+import 'package:presentation/viewmodels/my_page/my_page_viewmodel.dart';
 import 'package:presentation/widgets/my_page/sync_bottom_sheet.dart';
 import 'package:get_it/get_it.dart';
 import 'package:domain/usecases/auth/logout.dart';
+import 'package:provider/provider.dart';
 import 'my_page_setting_tile.dart';
 
 class MyPageSettingSection extends StatelessWidget {
@@ -10,6 +12,7 @@ class MyPageSettingSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final vm = context.read<MyPageViewModel>();
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -78,8 +81,12 @@ class MyPageSettingSection extends StatelessWidget {
         MyPageSettingTile(
           title: '로그아웃',
           onTap: () async {
-            await GetIt.instance<LogoutUseCase>()();
-            Navigator.pushNamedAndRemoveUntil(context, RoutePaths.root, (route) => false);
+            await vm.logout();
+            Navigator.pushNamedAndRemoveUntil(
+              context,
+              RoutePaths.root,
+                  (route) => false,
+            );
           },
         ),
       ],

--- a/toondo/packages/presentation/lib/widgets/my_page/my_page_setting_section.dart
+++ b/toondo/packages/presentation/lib/widgets/my_page/my_page_setting_section.dart
@@ -13,9 +13,11 @@ class MyPageSettingSection extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        const Text(
+        Text(
           '설정',
-          style: TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
+          style: Theme.of(context).textTheme.titleMedium?.copyWith(
+            fontWeight: FontWeight.w600,
+          ),
         ),
         const SizedBox(height: 16),
         MyPageSettingTile(

--- a/toondo/packages/presentation/lib/widgets/my_page/my_page_setting_tile.dart
+++ b/toondo/packages/presentation/lib/widgets/my_page/my_page_setting_tile.dart
@@ -9,23 +9,25 @@ class MyPageSettingTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final textColor = Theme.of(context).textTheme.bodyMedium?.color;
+
     return InkWell(
       onTap: onTap,
       child: Container(
         height: 52,
         padding: const EdgeInsets.symmetric(vertical: 14),
-        color: const Color(0xFFFCFCFC),
+        color: Colors.transparent,
         child: Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
             Text(
               title,
-              style: const TextStyle(
-                color: Color(0xFF1C1D1B),
-                fontSize: 14,
-                fontFamily: 'Pretendard Variable',
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                 fontWeight: FontWeight.w400,
+                fontSize: 14,
+                color: textColor,
                 letterSpacing: 0.21,
+                fontFamily: 'Pretendard Variable',
               ),
             ),
             if (trailing != null) trailing!,

--- a/toondo/packages/presentation/lib/widgets/my_page/notification_setting/notification_time_tile.dart
+++ b/toondo/packages/presentation/lib/widgets/my_page/notification_setting/notification_time_tile.dart
@@ -13,14 +13,16 @@ class NotificationTimeTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final textColor = Theme.of(context).textTheme.bodyMedium?.color;
+
     return ListTile(
       contentPadding: EdgeInsets.zero,
-      title: const Text(
+      title: Text(
         '리마인드 알림 시간',
-        style: TextStyle(
-          fontSize: 14,
+        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
           fontWeight: FontWeight.w400,
-          color: Color(0xFF1C1D1B),
+          fontSize: 14,
+          color: textColor,
         ),
       ),
       trailing: Row(
@@ -28,14 +30,14 @@ class NotificationTimeTile extends StatelessWidget {
         children: [
           Text(
             timeText,
-            style: const TextStyle(
-              fontSize: 14,
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
               fontWeight: FontWeight.w400,
-              color: Color(0xFF1C1D1B),
+              fontSize: 14,
+              color: textColor,
             ),
           ),
           const SizedBox(width: 8),
-          const Icon(Icons.arrow_forward_ios, size: 16, color: Color(0xFFD9D9D9)),
+          Icon(Icons.arrow_forward_ios, size: 16, color: IconTheme.of(context).color),
         ],
       ),
       onTap: () {

--- a/toondo/packages/presentation/lib/widgets/my_page/notification_setting/notification_time_tile.dart
+++ b/toondo/packages/presentation/lib/widgets/my_page/notification_setting/notification_time_tile.dart
@@ -3,16 +3,26 @@ import 'package:presentation/viewmodels/my_page/notification_setting/time_picker
 import 'package:presentation/widgets/my_page/notification_setting/time_picker/time_picker_bottom_sheet.dart';
 import 'package:provider/provider.dart';
 
-class NotificationTimeTile extends StatelessWidget {
-  final String timeText;
+import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
+import 'package:presentation/viewmodels/my_page/notification_setting/time_picker_viewmodel.dart';
+import 'package:presentation/widgets/my_page/notification_setting/time_picker/time_picker_bottom_sheet.dart';
+import 'package:provider/provider.dart';
 
-  const NotificationTimeTile({
-    super.key,
-    required this.timeText,
-  });
+import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
+import 'package:presentation/viewmodels/global/app_notification_viewmodel.dart';
+import 'package:presentation/viewmodels/my_page/notification_setting/time_picker_viewmodel.dart';
+import 'package:presentation/widgets/my_page/notification_setting/time_picker/time_picker_bottom_sheet.dart';
+import 'package:provider/provider.dart';
+
+class NotificationTimeTile extends StatelessWidget {
+  const NotificationTimeTile({super.key});
 
   @override
   Widget build(BuildContext context) {
+    final vm = context.watch<AppNotificationViewModel>();
+    final timeText = vm.settings.time;
     final textColor = Theme.of(context).textTheme.bodyMedium?.color;
 
     return ListTile(
@@ -45,12 +55,10 @@ class NotificationTimeTile extends StatelessWidget {
           context: context,
           isScrollControlled: true,
           backgroundColor: Colors.transparent,
-          builder: (_) {
-            return ChangeNotifierProvider(
-              create: (_) => TimePickerViewModel(),
-              child: TimePickerBottomSheet(),
-            );
-          },
+          builder: (_) => ChangeNotifierProvider(
+            create: (_) => GetIt.instance<TimePickerViewModel>(),
+            child: const TimePickerBottomSheet(),
+          ),
         );
       },
     );

--- a/toondo/packages/presentation/lib/widgets/my_page/notification_setting/notification_tip_text.dart
+++ b/toondo/packages/presentation/lib/widgets/my_page/notification_setting/notification_tip_text.dart
@@ -5,7 +5,9 @@ class NotificationTipText extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Row(
+    final textColor = Theme.of(context).textTheme.bodyMedium?.color;
+
+    return Row(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(
@@ -19,10 +21,10 @@ class NotificationTipText extends StatelessWidget {
         Expanded(
           child: Text(
             '원하는 시간에 to-do 작성 알림을 받아보세요!',
-            style: TextStyle(
-              color: Color(0xFF1C1D1B),
-              fontSize: 12,
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
               fontWeight: FontWeight.w400,
+              fontSize: 14,
+              color: textColor,
             ),
           ),
         ),

--- a/toondo/packages/presentation/lib/widgets/my_page/notification_setting/notification_toggle_tile.dart
+++ b/toondo/packages/presentation/lib/widgets/my_page/notification_setting/notification_toggle_tile.dart
@@ -3,11 +3,13 @@ import 'package:flutter/material.dart';
 class NotificationToggleTile extends StatelessWidget {
   final String title;
   final bool value;
+  final void Function(bool)? onChanged;
 
   const NotificationToggleTile({
     super.key,
     required this.title,
     required this.value,
+    this.onChanged,
   });
 
   @override
@@ -17,22 +19,13 @@ class NotificationToggleTile extends StatelessWidget {
     return Theme(
       data: Theme.of(context).copyWith(
         switchTheme: SwitchThemeData(
-          // 활성 상태
           thumbColor: WidgetStateProperty.resolveWith<Color>(
-                (states) {
-              if (states.contains(WidgetState.selected)) {
-                return const Color(0xFFFDFDFD); // 동그라미
-              }
-              return const Color(0xFFFDFDFD); // 비활도 동일
-            },
+                (states) => const Color(0xFFFDFDFD),
           ),
           trackColor: WidgetStateProperty.resolveWith<Color>(
-                (states) {
-              if (states.contains(MaterialState.selected)) {
-                return const Color(0xFF78B545); // 활성 배경
-              }
-              return const Color(0xFFD9D9D9); // 비활 배경
-            },
+                (states) => states.contains(MaterialState.selected)
+                ? const Color(0xFF78B545)
+                : const Color(0xFFD9D9D9),
           ),
           overlayColor: WidgetStateProperty.all(Colors.transparent),
           trackOutlineColor: WidgetStateProperty.all(Colors.transparent),
@@ -49,7 +42,7 @@ class NotificationToggleTile extends StatelessWidget {
           ),
         ),
         value: value,
-        onChanged: (_) {}, // TODO 추후 ViewModel 연결 예정
+        onChanged: onChanged,
       ),
     );
   }

--- a/toondo/packages/presentation/lib/widgets/my_page/notification_setting/notification_toggle_tile.dart
+++ b/toondo/packages/presentation/lib/widgets/my_page/notification_setting/notification_toggle_tile.dart
@@ -12,6 +12,8 @@ class NotificationToggleTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final textColor = Theme.of(context).textTheme.bodyMedium?.color;
+
     return Theme(
       data: Theme.of(context).copyWith(
         switchTheme: SwitchThemeData(
@@ -40,10 +42,10 @@ class NotificationToggleTile extends StatelessWidget {
         contentPadding: EdgeInsets.zero,
         title: Text(
           title,
-          style: const TextStyle(
-            fontSize: 14,
+          style: Theme.of(context).textTheme.bodyMedium?.copyWith(
             fontWeight: FontWeight.w400,
-            color: Color(0xFF1C1D1B),
+            fontSize: 14,
+            color: textColor,
           ),
         ),
         value: value,

--- a/toondo/packages/presentation/lib/widgets/my_page/notification_setting/time_picker/time_picker_bottom_sheet.dart
+++ b/toondo/packages/presentation/lib/widgets/my_page/notification_setting/time_picker/time_picker_bottom_sheet.dart
@@ -4,6 +4,18 @@ import 'package:presentation/widgets/bottom_sheet/custom_bottom_sheet.dart';
 import 'package:presentation/widgets/my_page/notification_setting/time_picker/time_picker_column.dart';
 import 'package:provider/provider.dart';
 
+import 'package:flutter/material.dart';
+import 'package:presentation/viewmodels/my_page/notification_setting/time_picker_viewmodel.dart';
+import 'package:presentation/widgets/bottom_sheet/custom_bottom_sheet.dart';
+import 'package:presentation/widgets/my_page/notification_setting/time_picker/time_picker_column.dart';
+import 'package:provider/provider.dart';
+
+import 'package:flutter/material.dart';
+import 'package:presentation/viewmodels/my_page/notification_setting/time_picker_viewmodel.dart';
+import 'package:presentation/widgets/bottom_sheet/custom_bottom_sheet.dart';
+import 'package:presentation/widgets/my_page/notification_setting/time_picker/time_picker_column.dart';
+import 'package:provider/provider.dart';
+
 class TimePickerBottomSheet extends StatelessWidget {
   const TimePickerBottomSheet({super.key});
 
@@ -15,7 +27,7 @@ class TimePickerBottomSheet extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final viewModel = context.read<TimePickerViewModel>();
+    final viewModel = context.watch<TimePickerViewModel>();
 
     return CustomBottomSheet(
       title: '시간 설정',
@@ -24,11 +36,13 @@ class TimePickerBottomSheet extends StatelessWidget {
         children: [
           TimePickerColumn(
             items: ['오전', '오후'],
+            initialItem: viewModel.ampm,
             onItemSelected: viewModel.setAmPm,
           ),
           const SizedBox(width: 8),
           TimePickerColumn(
             items: _hourItems,
+            initialItem: int.parse(viewModel.hour).toString(),
             onItemSelected: viewModel.setHour,
           ),
           const Padding(
@@ -44,6 +58,7 @@ class TimePickerBottomSheet extends StatelessWidget {
           ),
           TimePickerColumn(
             items: _minuteItems,
+            initialItem: viewModel.minute,
             onItemSelected: viewModel.setMinute,
           ),
         ],
@@ -52,8 +67,8 @@ class TimePickerBottomSheet extends StatelessWidget {
         CommonBottomSheetButtonData(
           label: '저장하기',
           filled: false,
-          onPressed: () {
-            viewModel.saveSelectedTime(); // 저장 처리
+          onPressed: () async {
+            await viewModel.saveSelectedTime();
             Navigator.pop(context);
           },
         ),

--- a/toondo/packages/presentation/lib/widgets/my_page/notification_setting/time_picker/time_picker_column.dart
+++ b/toondo/packages/presentation/lib/widgets/my_page/notification_setting/time_picker/time_picker_column.dart
@@ -3,19 +3,25 @@ import 'package:flutter/material.dart';
 
 class TimePickerColumn extends StatelessWidget {
   final List<String> items;
+  final String? initialItem;
   final Function(String)? onItemSelected;
 
   const TimePickerColumn({
     super.key,
     required this.items,
+    this.initialItem,
     this.onItemSelected,
   });
 
   @override
   Widget build(BuildContext context) {
+    final initialIndex =
+    initialItem != null ? items.indexOf(initialItem!) : 0;
+
     return Expanded(
       child: CupertinoPicker(
         itemExtent: 36,
+        scrollController: FixedExtentScrollController(initialItem: initialIndex),
         onSelectedItemChanged: (index) {
           if (onItemSelected != null) {
             onItemSelected!(items[index]);

--- a/toondo/packages/presentation/pubspec.lock
+++ b/toondo/packages/presentation/pubspec.lock
@@ -669,6 +669,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
+  package_info_plus:
+    dependency: "direct main"
+    description:
+      name: package_info_plus
+      sha256: "7976bfe4c583170d6cdc7077e3237560b364149fcd268b5f53d95a991963b191"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.3.0"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      sha256: "6c935fb612dff8e3cc9632c2b301720c77450a126114126ffaafe28d2e87956c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.0"
   path:
     dependency: transitive
     description:

--- a/toondo/packages/presentation/pubspec.lock
+++ b/toondo/packages/presentation/pubspec.lock
@@ -925,6 +925,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.3"
+  shared_preferences:
+    dependency: transitive
+    description:
+      name: shared_preferences
+      sha256: "6e8bf70b7fef813df4e9a36f658ac46d107db4b4cfe1048b477d4e453a8159f5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.3"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: "20cbd561f743a342c76c151d6ddb93a9ce6005751e7aa458baad3858bfbfb6ac"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.10"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "6a52cfcdaeac77cad8c97b539ff688ccfc458c007b4db12be584fbe5c0e49e03"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.4"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   shelf:
     dependency: transitive
     description:
@@ -1188,4 +1244,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.7.0 <4.0.0"
-  flutter: ">=3.24.0"
+  flutter: ">=3.27.0"

--- a/toondo/packages/presentation/pubspec.yaml
+++ b/toondo/packages/presentation/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
   audioplayers: ^6.1.1
   injectable: ^2.5.0
   rxdart: ^0.28.0
+  package_info_plus: ^8.3.0
 
 dev_dependencies:
   flutter_test:

--- a/toondo/pubspec.lock
+++ b/toondo/pubspec.lock
@@ -785,6 +785,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
+  package_info_plus:
+    dependency: "direct main"
+    description:
+      name: package_info_plus
+      sha256: "7976bfe4c583170d6cdc7077e3237560b364149fcd268b5f53d95a991963b191"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.3.0"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      sha256: "6c935fb612dff8e3cc9632c2b301720c77450a126114126ffaafe28d2e87956c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.0"
   path:
     dependency: transitive
     description:

--- a/toondo/pubspec.lock
+++ b/toondo/pubspec.lock
@@ -1064,6 +1064,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.3"
+  shared_preferences:
+    dependency: transitive
+    description:
+      name: shared_preferences
+      sha256: "6e8bf70b7fef813df4e9a36f658ac46d107db4b4cfe1048b477d4e453a8159f5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.3"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: "20cbd561f743a342c76c151d6ddb93a9ce6005751e7aa458baad3858bfbfb6ac"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.10"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "6a52cfcdaeac77cad8c97b539ff688ccfc458c007b4db12be584fbe5c0e49e03"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.4"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   shelf:
     dependency: transitive
     description:
@@ -1359,4 +1415,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.7.0 <4.0.0"
-  flutter: ">=3.24.0"
+  flutter: ">=3.27.0"

--- a/toondo/pubspec.yaml
+++ b/toondo/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
   get_it: ^8.0.3
   audioplayers: ^6.1.1
   injectable: ^2.5.0
+  package_info_plus: ^8.3.0
   flutter_gen:
   
 dev_dependencies:


### PR DESCRIPTION
### 개요
- 마이페이지에 띄우는 **개인 정보 데이터를 실제 데이터와 연결**하고, **테마 설정**, **로그아웃** 등의 기능을 동작하도록 하였습니다. (전화번호는 아직 저장되고 있지 않는 것 같습니다. 다만, 개인정보라 앱 내 저장보다는 서버에 요청하는 방식이어야할 것 같아 백엔드와 회의 후 수정하겠습니다.)
- 알림 및 테마 관련 UseCase, Repository, Entity, ViewModel 등을 도메인-데이터-프레젠테이션 전반에 걸쳐 설계 및 반영하였습니다.
- User 엔티티 및 모델에 phoneNumber, createdAt 등의 필드를 추가하였으며, 관련 UI/로컬 저장 구조도 정비하였습니다. (엔티티 변경에 대해 서버측과 논의가 필요할 것 같은데 지금 전체적으로 코드를 엎고 있다고 하여 이에 관해선 다음 회의 때 다시 한 번 이야기해보겠습니다. 폰넘버는 에러를 막기 위해 임시 방편으로 넣었으나 서버측 API 정비 되면 이 또한 없애는 방향으로 가야할 것 같습니다.)

### 결과
- 마이페이지 진입 시 현재 유저 데이터를 불러와서 띄우고 있습니다.
- 테마 설정 화면이 이제 실시간 상태 반영 및 저장 기능을 갖추었고, 사용자 테마 저장은 SharedPref 를 사용하였습니다. 알림 설정도 SharedPref 에 저장을 하도록 코드를 짜긴 하였으나, 알림 관련은 그 때 확실하게 논의하지 않아서 해당 기능이 실제 표현되지는 않고 있습니다.

<p float="left">
  <img src="https://github.com/user-attachments/assets/9436c11d-2e5d-4395-9acc-2ea579149ca7" width="45%" />
  <img src="https://github.com/user-attachments/assets/ae212af6-cb22-4423-882d-2586b1f4d0a6" width="45%" />
</p>

https://github.com/user-attachments/assets/580877c3-4c63-4293-a83c-9b0bd29e9e2f


### 주요 변경
<알림 설정 관련>
- NotificationSettings 도메인 엔티티 생성
- AppNotificationViewModel 및 NotificationSettingViewModel 도입
- SharedPreferences 기반 알림 설정 저장소(NotificationSettingRepositoryImpl) 구현
- 알림 관련 UseCase (GetNotificationSettingsUseCase, SetNotificationSettingsUseCase) 도입 및 주입

<테마 설정 관련>
- ThemeModeType enum 및 ThemeModeTypeX 확장 정의
- 테마 전역 관리용 AppThemeViewModel 도입 및 앱 시작 시 초기 테마 로딩 처리
- ThemeRepository, ThemeRepositoryImpl 추가 및 SharedPreferences 연동

<유저 정보 관련>
- User 엔티티/모델 정비 
- User 도메인 객체에 createdAt, phoneNumber 필드 추가
- (보안상 민감한 password, loginId는 도메인 객체에서 제외하고 서버에서 필요할 때만 조회하도록 설계해야할 것 같아 이 또한 서버와 논의 필요)

<의존성 주입 설정 보완>
- data/lib/injection/di_module.dart, domain/lib/injection/di.config.dart 등에서 SharedPreferences, 알림/테마 리포지토리 바인딩 추가

<앱 버전 관련>
-  package_info_plus 패키지를 활용한 앱 버전 정보 표시

### 수정 및 추가된 파일
- 추가: get_notification_settings.dart, set_notification_settings.dart, notification_settings.dart, theme_mode_type.dart
- 수정: user_model.dart, user.dart, user_repository_impl.dart, user_local_datasource.dart
- 추가: app_notification_viewmodel.dart, notification_setting_viewmodel.dart, theme_repository.dart, theme_repository_impl.dart
- 수정: di.config.dart, main.dart 등 앱 초기화 로직

### 그 외 전달 사항
1.  패스워드와 같이 **민감한 정보는 UI에 띄우는게 좋지 않아보입니다. 흔히 비밀번호 변경에 사용하는 방식으로 사용자에게 현재 비밀번호를 입력 하도록하여 '기존 비밀번호 + 새로운 비밀번호' 로 서버에 POST 요청을 하는 게 어떨까 싶은데 이는 기획팀, 백엔드팀과 논의가 필요할 것 같아 다음 회의에 논의 후 적용**하겠습니다.
- 기존 UI
![rlwhs](https://github.com/user-attachments/assets/5e40635f-acbe-40c1-8072-ea5007a21dbc)
- 제안하는 방식
![attachment](https://github.com/user-attachments/assets/1d3e9178-f4ae-4bd2-8101-3214d0550530)

2. 서버측에 유저 정보에 가입일까지 저장 및 조회 가능하도록 변경해달라고 요청했습니다. 다만, 현재 전체적인 수정을 진행중이라고 하셔서 조금 걸릴 것 같습니다. 현재는 '함께한지 0일'로 표시되고 있으며 서버의 변경과 함께 이 부분 수정 예정입니다.

3. 그리고, 도메인 User 엔티티에서 loginId(사용자계정), phoneNumber(전화 번호), password(비밀번호) 등은 앱 자체 저장 시 보안 상 위험이 존재하여, 필요 시 별도 API 호출 후 단건으로만 가져오고, 엔티티에는 포함하지 않는 것이 좋다고 합니다. 따라서 서버 안정화가 되면 현재 엔티티에 존재하는 loginId(사용자계정), phoneNumber(전화 번호)도 제거 후 서버에 해당 api 을 요청하는 방식으로 변경할까 합니다.

4. 가입일에 따라 캐릭터가 커지는 부분에서 커지는 가입일의 기준은 다음 회의 때 기획팀에게 여쭤보겠습니다.

5. 닉네임, 비밀번호, 전화번호 등의 변경 기능은 현재 작동하고 있는 것 같지 않던데  백엔드와 회의 후 다음 PR에서 진행하겠습니다.

6. 테마 설정을 위해 scaffold 의 백그라운드 컬러 설정을 하드 코딩이 아닌 Theme.of(context).scaffoldBackgroundColor를 사용하도록 수정하여 다크모드 및 라이트모드 전환 시 자동 반영되도록 해야합니다. 혹시라도 놓친 부분이 있다면 Theme.of(context).scaffoldBackgroundColor 을 사용하도록 변경 부탁드립니다.



