### PR TITLE
fix: 실물 기기 리마인드 알림 수신 불가 해결 및 UI 렌더링 품질 개선

### DIFF
--- a/toondo/android/app/build.gradle.kts
+++ b/toondo/android/app/build.gradle.kts
@@ -1,3 +1,6 @@
+import java.util.Properties
+import java.io.FileInputStream
+
 plugins {
     id("com.android.application")
     id("kotlin-android")
@@ -5,11 +8,16 @@ plugins {
     id("dev.flutter.flutter-gradle-plugin")
 }
 
+val keyPropertiesFile = rootProject.file("key.properties")
+val keyProperties = Properties()
+if (keyPropertiesFile.exists()) {
+    keyProperties.load(FileInputStream(keyPropertiesFile))
+}
+
 android {
-    namespace = "com.example.toondo"
+    namespace = "com.dreamers.toondo"
     compileSdk = flutter.compileSdkVersion
-   // ndkVersion = flutter.ndkVersion
-    ndkVersion = "27.0.12077973"
+    ndkVersion = "28.2.13676358"
 
     compileOptions {
         isCoreLibraryDesugaringEnabled = true
@@ -21,11 +29,17 @@ android {
         jvmTarget = JavaVersion.VERSION_17.toString()
     }
 
+    signingConfigs {
+        create("release") {
+            keyAlias = keyProperties["keyAlias"] as String
+            keyPassword = keyProperties["keyPassword"] as String
+            storeFile = keyProperties["storeFile"]?.let { file(it) }
+            storePassword = keyProperties["storePassword"] as String
+        }
+    }
+
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId = "com.example.toondo"
-        // You can update the following values to match your application needs.
-        // For more information, see: https://flutter.dev/to/review-gradle-config.
+        applicationId = "com.dreamers.toondo"
         minSdk = flutter.minSdkVersion
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
@@ -34,14 +48,11 @@ android {
 
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig = signingConfigs.getByName("debug")
-
+            signingConfig = signingConfigs.getByName("release")
             // Release에서 R8/ProGuard 사용 시 flutter_local_notifications(TypeToken/Gson) 관련 이슈가
             // 발생할 수 있어, proguard-rules.pro에서 제네릭 시그니처 보존 규칙을 포함합니다.
-            isMinifyEnabled = true
-            isShrinkResources = true
+            isMinifyEnabled = false
+            isShrinkResources = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro",

--- a/toondo/android/app/proguard-rules.pro
+++ b/toondo/android/app/proguard-rules.pro
@@ -1,6 +1,18 @@
 # Release shrinker(R8/ProGuard) 대응
 # - flutter_local_notifications 내부에서 Gson TypeToken 제네릭 시그니처가 필요합니다.
 
+# Flutter MainActivity 보존 (R8가 제거하지 않도록)
+-keep class io.flutter.app.** { *; }
+-keep class io.flutter.plugin.** { *; }
+-keep class io.flutter.util.** { *; }
+-keep class io.flutter.view.** { *; }
+-keep class io.flutter.** { *; }
+-keep class io.flutter.plugins.** { *; }
+-keep class com.dreamers.toondo.** { *; }
+
+# Play Core (deferred components - 미사용 시 경고 억제)
+-dontwarn com.google.android.play.core.**
+
 # Keep generic signatures (TypeToken needs this)
 -keepattributes Signature,*Annotation*,InnerClasses,EnclosingMethod
 

--- a/toondo/android/app/src/main/AndroidManifest.xml
+++ b/toondo/android/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
+    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS"/>
     <application
         android:label="toondo"
         android:name="${applicationName}"

--- a/toondo/android/app/src/main/kotlin/com/dreamers/toondo/MainActivity.kt
+++ b/toondo/android/app/src/main/kotlin/com/dreamers/toondo/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.example.toondo
+package com.dreamers.toondo
 
 import android.os.Bundle
 import android.os.Process

--- a/toondo/packages/common/lib/notification/exact_alarm_helper.dart
+++ b/toondo/packages/common/lib/notification/exact_alarm_helper.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 import 'package:android_intent_plus/android_intent.dart';
 import 'package:android_intent_plus/flag.dart';
+import 'package:device_info_plus/device_info_plus.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 
 Future<String?> _packageName() async {
@@ -40,6 +41,40 @@ Future<void> openAppNotificationSettings() async {
     );
     await intent.launch();
   } catch (_) {
+    await openAppDetailsSettings();
+  }
+}
+
+/// 삼성 기기 여부 확인
+Future<bool> isSamsungDevice() async {
+  if (!Platform.isAndroid) return false;
+  try {
+    final info = await DeviceInfoPlugin().androidInfo;
+    return info.manufacturer.toLowerCase() == 'samsung';
+  } catch (_) {
+    return false;
+  }
+}
+
+/// 삼성 기기의 앱 배터리 설정 화면 열기
+/// Settings > Apps > [앱] > Battery > Unrestricted 경로로 안내
+Future<void> openSamsungBatterySettings() async {
+  if (!Platform.isAndroid) return;
+  final pkg = await _packageName();
+  if (pkg == null) return;
+
+  // Samsung Device Care의 앱별 배터리 설정 직접 오픈 시도
+  try {
+    final intent = AndroidIntent(
+      action: 'android.intent.action.MAIN',
+      package: 'com.samsung.android.lool',
+      componentName: 'com.samsung.android.lool.pages.AppSleepModeActivity',
+      flags: <int>[Flag.FLAG_ACTIVITY_NEW_TASK],
+    );
+    await intent.launch();
+    return;
+  } catch (_) {
+    // 삼성 내부 Activity 없으면 앱 상세로 폴백 (배터리 탭 수동 탐색)
     await openAppDetailsSettings();
   }
 }

--- a/toondo/packages/common/lib/notification/reminder_notification_service.dart
+++ b/toondo/packages/common/lib/notification/reminder_notification_service.dart
@@ -1,4 +1,3 @@
-import 'package:common/gen/assets.gen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:injectable/injectable.dart';

--- a/toondo/packages/common/lib/notification/reminder_notification_service.dart
+++ b/toondo/packages/common/lib/notification/reminder_notification_service.dart
@@ -30,7 +30,6 @@ class ReminderNotificationService {
 
   Future<void> init() async {
     if (_inited) return;
-    _inited = true;
 
     tz.initializeTimeZones();
     try {
@@ -55,6 +54,8 @@ class ReminderNotificationService {
       importance: Importance.high,
       playSound: true,
     ));
+
+    _inited = true;
   }
 
   /// "오전 08:30" / "오후 07:05" / "08:30" (24시간) 모두 지원

--- a/toondo/packages/common/pubspec.yaml
+++ b/toondo/packages/common/pubspec.yaml
@@ -21,4 +21,5 @@ dependencies:
   timezone:
   android_intent_plus:
   package_info_plus:
+  device_info_plus:
   permission_handler:

--- a/toondo/packages/presentation/lib/designsystem/components/bottom_sheets/app_goal_icon_bottom_sheet.dart
+++ b/toondo/packages/presentation/lib/designsystem/components/bottom_sheets/app_goal_icon_bottom_sheet.dart
@@ -159,14 +159,17 @@ class AppGoalIconBottomSheet extends StatelessWidget {
       child: Container(
         width: 40.0, // 정수 픽셀 (ScreenUtil 미사용)
         height: 40.0, // 정수 픽셀 (ScreenUtil 미사용)
-        decoration: BoxDecoration(
+        decoration: const BoxDecoration(
+          shape: BoxShape.circle,
+        ),
+        foregroundDecoration: BoxDecoration(
           shape: BoxShape.circle,
           border: Border.all(
             color: AppColors.borderDisabled,
             width: 1.0, // 정수 픽셀
           ),
         ),
-        clipBehavior: Clip.antiAlias,
+        clipBehavior: Clip.antiAliasWithSaveLayer,
         child: ClipOval(
           child: SizedBox.expand(
             child: Image.file(
@@ -272,7 +275,10 @@ class AppGoalIconBottomSheet extends StatelessWidget {
                   width: 40.0, // 정수 픽셀 (ScreenUtil 미사용)
                   height: 40.0, // 정수 픽셀 (ScreenUtil 미사용)
                   padding: EdgeInsets.all(8.0), // 정수 픽셀
-                  decoration: BoxDecoration(
+                  decoration: const BoxDecoration(
+                    shape: BoxShape.circle,
+                  ),
+                  foregroundDecoration: BoxDecoration(
                     shape: BoxShape.circle,
                     border: Border.all(
                       color: AppColors.borderDisabled,

--- a/toondo/packages/presentation/lib/designsystem/components/calendars/calendar_bottom_sheet.dart
+++ b/toondo/packages/presentation/lib/designsystem/components/calendars/calendar_bottom_sheet.dart
@@ -201,7 +201,7 @@ class _SelectDateBottomSheetState extends State<SelectDateBottomSheet> {
                           '${day.day}',
                           style: AppTypography.h1Bold.copyWith(
                             color: AppColors.green500,
-                            fontWeight: FontWeight.w900,
+                            fontWeight: FontWeight.w700,
                           ),
                         ),
                       );
@@ -238,10 +238,10 @@ class _SelectDateBottomSheetState extends State<SelectDateBottomSheet> {
                 ),
 
                 daysOfWeekStyle: DaysOfWeekStyle(
-                  weekendStyle: AppTypography.body2SemiBold.copyWith(
+                  weekendStyle: AppTypography.caption1SemiBold.copyWith(
                     color: AppColors.status100.withOpacity(0.3),
                   ),
-                  weekdayStyle: AppTypography.body2SemiBold.copyWith(
+                  weekdayStyle: AppTypography.caption1SemiBold.copyWith(
                     color: AppColors.status100.withOpacity(0.3),
                   ),
                 ),

--- a/toondo/packages/presentation/lib/designsystem/components/character/old/speech_bubble_old.dart
+++ b/toondo/packages/presentation/lib/designsystem/components/character/old/speech_bubble_old.dart
@@ -180,11 +180,12 @@ class _SpeechBubblePainter extends CustomPainter {
     if (showTail) {
       final tailWidth = 16.0;
       final tailHeight = 12.0;
-      final tailX = (size.width / 2) - (tailWidth / 2) + offset.dx;
+      final tailX = ((size.width - tailWidth) / 2 + offset.dx).roundToDouble();
+      final tailHalf = (tailWidth / 2).roundToDouble();
       final tailY = rect.bottom + offset.dy;
 
       path.moveTo(tailX, tailY);
-      path.lineTo(tailX + tailWidth / 2, tailY + tailHeight);
+      path.lineTo(tailX + tailHalf, tailY + tailHeight);
       path.lineTo(tailX + tailWidth, tailY);
       path.close();
     }

--- a/toondo/packages/presentation/lib/designsystem/components/character/speech_bubble.dart
+++ b/toondo/packages/presentation/lib/designsystem/components/character/speech_bubble.dart
@@ -38,7 +38,7 @@ class SpeechBubble extends StatelessWidget {
 
     final double bubbleW =
     (textPainter.width + (padH * 2) + extraWidth).clamp(0, maxW);
-    final double bubbleH = textPainter.height + padTop + padBottom + 6.h; // 꼬리 높이 포함
+    final double bubbleH = (textPainter.height + padTop + padBottom + 6.h).roundToDouble(); // 꼬리 높이 포함
 
     return CustomPaint(
       painter: SpeechBubblePainter(
@@ -89,16 +89,17 @@ class SpeechBubblePainter extends CustomPainter {
   @override
   void paint(Canvas canvas, Size size) {
     final bubbleHeight = height - tailHeight;
-    final tailCenter = width / 2;
+    final tailCenter = (width / 2).roundToDouble();
+    final tailHalf = (tailWidth / 2).roundToDouble();
 
     final path = Path()
       ..moveTo(radius, 0)
       ..arcToPoint(Offset(0, radius), radius: Radius.circular(radius), clockwise: false)
       ..lineTo(0, bubbleHeight - radius)
       ..arcToPoint(Offset(radius, bubbleHeight), radius: Radius.circular(radius), clockwise: false)
-      ..lineTo(tailCenter - tailWidth / 2, bubbleHeight)
+      ..lineTo(tailCenter - tailHalf, bubbleHeight)
       ..lineTo(tailCenter, bubbleHeight + tailHeight)
-      ..lineTo(tailCenter + tailWidth / 2, bubbleHeight)
+      ..lineTo(tailCenter + tailHalf, bubbleHeight)
       ..lineTo(width - radius, bubbleHeight)
       ..arcToPoint(Offset(width, bubbleHeight - radius), radius: Radius.circular(radius), clockwise: false)
       ..lineTo(width, radius)

--- a/toondo/packages/presentation/lib/designsystem/components/inputs/app_input_field.dart
+++ b/toondo/packages/presentation/lib/designsystem/components/inputs/app_input_field.dart
@@ -15,6 +15,7 @@ class AppInputField extends StatefulWidget {
   final VoidCallback? onToggleVisibility;
   final ValueChanged<String>? onChanged;
   final bool isEnabled;
+  final FocusNode? focusNode;
 
   const AppInputField({
     super.key,
@@ -27,6 +28,7 @@ class AppInputField extends StatefulWidget {
     this.onToggleVisibility,
     this.isEnabled = true,
     this.onChanged,
+    this.focusNode,
   });
 
   @override
@@ -99,6 +101,7 @@ class _AppInputFieldState extends State<AppInputField> {
           height: AppDimensions.inputFieldHeight,
           child: TextField(
             cursorColor: AppColors.green500,
+            focusNode: widget.focusNode,
             controller: widget.controller,
             enabled: widget.isEnabled,
             obscureText: _obscure,

--- a/toondo/packages/presentation/lib/designsystem/components/items/app_goal_item.dart
+++ b/toondo/packages/presentation/lib/designsystem/components/items/app_goal_item.dart
@@ -197,12 +197,15 @@ class _AppGoalItemState extends State<AppGoalItem> {
       decoration: BoxDecoration(
         shape: BoxShape.circle,
         color: AppColors.backgroundNormal,
+      ),
+      foregroundDecoration: BoxDecoration(
+        shape: BoxShape.circle,
         border: Border.all(
           color: borderColor,
           width: 1.5,
         ),
       ),
-      clipBehavior: Clip.antiAlias,
+      clipBehavior: Clip.antiAliasWithSaveLayer,
       padding: isCustomIcon ? EdgeInsets.zero : EdgeInsets.all(innerPadding),
       child: isCustomIcon
           ? ClipOval(

--- a/toondo/packages/presentation/lib/viewmodels/global/app_notification_viewmodel.dart
+++ b/toondo/packages/presentation/lib/viewmodels/global/app_notification_viewmodel.dart
@@ -37,7 +37,7 @@ class AppNotificationViewModel extends ChangeNotifier {
             soundOn: s.sound,
             timeHHmm: s.time,
           )
-          .timeout(const Duration(seconds: 3));
+          .timeout(const Duration(seconds: 10));
     } on PlatformException catch (e) {
       debugPrint('[Notification] sync failed (ignored): $e');
     } on TimeoutException catch (e) {

--- a/toondo/packages/presentation/lib/views/auth/login/login_body.dart
+++ b/toondo/packages/presentation/lib/views/auth/login/login_body.dart
@@ -56,7 +56,6 @@ class LoginBody extends StatelessWidget {
             style: AppTypography.body2Regular.copyWith(color: AppColors.red700),
           ),
         ],
-        SizedBox(height: AppSpacing.v32),
       ],
     );
   }

--- a/toondo/packages/presentation/lib/views/auth/login/login_screen.dart
+++ b/toondo/packages/presentation/lib/views/auth/login/login_screen.dart
@@ -41,20 +41,29 @@ class _LoginScreenState extends State<LoginScreen> {
         builder: (context, viewModel, child) {
           return BaseScaffold(
             title: '로그인',
-            body: LoginBody(passedLoginId: passedLoginId),
-            bottomWidget: SafeArea(
-              minimum: EdgeInsets.all(AppSpacing.a24),
-              child: DoubleActionButtons(
-                backText: '뒤로',
-                nextText: '다음으로',
-                onBack: () => Navigator.pop(context),
-                onNext: () async {
-                  final success = await viewModel.login();
-                  if (success && context.mounted) {
-                    Navigator.pushReplacementNamed(context, '/home');
-                  }
-                },
-              ),
+            body: Column(
+              children: [
+                Expanded(
+                  child: SingleChildScrollView(
+                    keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
+                    child: LoginBody(passedLoginId: passedLoginId),
+                  ),
+                ),
+                Padding(
+                  padding: EdgeInsets.symmetric(vertical: AppSpacing.a24),
+                  child: DoubleActionButtons(
+                    backText: '뒤로',
+                    nextText: '다음으로',
+                    onBack: () => Navigator.pop(context),
+                    onNext: () async {
+                      final success = await viewModel.login();
+                      if (success && context.mounted) {
+                        Navigator.pushReplacementNamed(context, '/home');
+                      }
+                    },
+                  ),
+                ),
+              ],
             ),
           );
         },

--- a/toondo/packages/presentation/lib/views/auth/signup/steps/signup_step1.dart
+++ b/toondo/packages/presentation/lib/views/auth/signup/steps/signup_step1.dart
@@ -16,28 +16,37 @@ class SignupStep1 extends StatelessWidget {
       builder: (context, viewModel, child) {
         return BaseScaffold(
           title: '회원가입',
-          body: SignupStep1Body(),
-          bottomWidget: SafeArea(
-            minimum: EdgeInsets.all(AppSpacing.a24),
-            child: DoubleActionButtons(
-              backText: '뒤로',
-              nextText: '아이디 중복 확인하기',
-              onBack: () {
-                Navigator.pop(context);
-              },
-              onNext: () {
-                viewModel.validateLoginId().then((isValid) {
-                  if (isValid) {
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                        builder: (context) => SignupStep2(loginId: viewModel.loginId),
-                      ),
-                    );
-                  }
-                });
-              },
-            ),
+          body: Column(
+            children: [
+              Expanded(
+                child: SingleChildScrollView(
+                  keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
+                  child: SignupStep1Body(),
+                ),
+              ),
+              Padding(
+                padding: EdgeInsets.symmetric(vertical: AppSpacing.a24),
+                child: DoubleActionButtons(
+                  backText: '뒤로',
+                  nextText: '아이디 중복 확인하기',
+                  onBack: () {
+                    Navigator.pop(context);
+                  },
+                  onNext: () {
+                    viewModel.validateLoginId().then((isValid) {
+                      if (isValid) {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (context) => SignupStep2(loginId: viewModel.loginId),
+                          ),
+                        );
+                      }
+                    });
+                  },
+                ),
+              ),
+            ],
           ),
         );
       },

--- a/toondo/packages/presentation/lib/views/auth/signup/steps/signup_step1_body.dart
+++ b/toondo/packages/presentation/lib/views/auth/signup/steps/signup_step1_body.dart
@@ -26,7 +26,6 @@ class SignupStep1Body extends StatelessWidget {
           errorText: viewModel.loginIdError,
           onChanged: (value) => viewModel.setLoginId(value),
         ),
-        Spacer()
       ],
     );
   }

--- a/toondo/packages/presentation/lib/views/auth/signup/steps/signup_step2.dart
+++ b/toondo/packages/presentation/lib/views/auth/signup/steps/signup_step2.dart
@@ -42,15 +42,24 @@ class SignupStep2 extends StatelessWidget {
 
         return BaseScaffold(
           title: '회원정보 확인',
-          body: SignupStep2Body(),
-          bottomWidget: SafeArea(
-            minimum: EdgeInsets.all(AppSpacing.a24),
-            child: DoubleActionButtons(
-              backText: '뒤로',
-              nextText: '다음으로',
-              onBack: () => Navigator.pop(context),
-              onNext: () => viewModel.validatePassword(),
-            ),
+          body: Column(
+            children: [
+              Expanded(
+                child: SingleChildScrollView(
+                  keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
+                  child: SignupStep2Body(),
+                ),
+              ),
+              Padding(
+                padding: EdgeInsets.symmetric(vertical: AppSpacing.a24),
+                child: DoubleActionButtons(
+                  backText: '뒤로',
+                  nextText: '다음으로',
+                  onBack: () => Navigator.pop(context),
+                  onNext: () => viewModel.validatePassword(),
+                ),
+              ),
+            ],
           ),
         );
       },

--- a/toondo/packages/presentation/lib/views/auth/signup/steps/signup_step2_body.dart
+++ b/toondo/packages/presentation/lib/views/auth/signup/steps/signup_step2_body.dart
@@ -6,8 +6,46 @@ import 'package:presentation/designsystem/typography/app_typography.dart';
 import 'package:presentation/viewmodels/signup/signup_viewmodel.dart';
 import 'package:provider/provider.dart';
 
-class SignupStep2Body extends StatelessWidget {
+class SignupStep2Body extends StatefulWidget {
   const SignupStep2Body({super.key});
+
+  @override
+  State<SignupStep2Body> createState() => _SignupStep2BodyState();
+}
+
+class _SignupStep2BodyState extends State<SignupStep2Body> {
+  final _passwordFocusNode = FocusNode();
+  final _confirmFieldKey = GlobalKey();
+
+  @override
+  void initState() {
+    super.initState();
+    _passwordFocusNode.addListener(_onPasswordFocus);
+  }
+
+  void _onPasswordFocus() {
+    if (!_passwordFocusNode.hasFocus) return;
+    // 키보드 애니메이션(~300ms) 완료 후 호출해야 정확한 레이아웃 기준으로 스크롤됨
+    Future.delayed(const Duration(milliseconds: 350), () {
+      if (!mounted) return;
+      final ctx = _confirmFieldKey.currentContext;
+      if (ctx != null) {
+        Scrollable.ensureVisible(
+          ctx,
+          duration: const Duration(milliseconds: 200),
+          curve: Curves.easeOut,
+          alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtEnd,
+        );
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _passwordFocusNode.removeListener(_onPasswordFocus);
+    _passwordFocusNode.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -21,6 +59,7 @@ class SignupStep2Body extends StatelessWidget {
         SizedBox(height: AppSpacing.v56),
         AppInputField(
           label: '비밀번호',
+          focusNode: _passwordFocusNode,
           controller: viewModel.passwordTextController,
           hintText: '영문, 숫자 조합 8~20자로 입력해주세요',
           obscureText: viewModel.isPasswordObscured,
@@ -31,6 +70,7 @@ class SignupStep2Body extends StatelessWidget {
         ),
         SizedBox(height: AppSpacing.v24),
         AppInputField(
+          key: _confirmFieldKey,
           label: '비밀번호 확인',
           controller: viewModel.confirmPasswordTextController,
           hintText: '영문, 숫자 조합 8~20자로 입력해주세요',
@@ -40,7 +80,6 @@ class SignupStep2Body extends StatelessWidget {
           errorText: viewModel.confirmPasswordError,
           onChanged: (value) => viewModel.setConfirmPassword(value),
         ),
-        Spacer()
       ],
     );
   }

--- a/toondo/packages/presentation/lib/views/goal/widget/goal_name_input_field.dart
+++ b/toondo/packages/presentation/lib/views/goal/widget/goal_name_input_field.dart
@@ -69,6 +69,10 @@ class _GoalNameInputFieldState extends State<GoalNameInputField> {
                       height: 40,
                       decoration: BoxDecoration(
                         shape: BoxShape.circle,
+                        color: Colors.white,
+                      ),
+                      foregroundDecoration: BoxDecoration(
+                        shape: BoxShape.circle,
                         border: Border.all(
                           color:
                               viewModel.selectedIcon != null
@@ -76,9 +80,8 @@ class _GoalNameInputFieldState extends State<GoalNameInputField> {
                                   : AppColors.borderUnselected,
                           width: 1,
                         ),
-                        color: Colors.white,
                       ),
-                      clipBehavior: Clip.antiAlias,
+                      clipBehavior: Clip.antiAliasWithSaveLayer,
                       child:
                           viewModel.selectedIcon != null
                               ? _buildIconWidget(viewModel.selectedIcon!)

--- a/toondo/packages/presentation/lib/views/home/widget/home_list_item.dart
+++ b/toondo/packages/presentation/lib/views/home/widget/home_list_item.dart
@@ -90,7 +90,7 @@ class HomeListItem extends StatelessWidget {
                           title,
                           style: AppTypography.body2Bold.copyWith(
                             color: AppColors.status100,
-                            height: 1.0,
+                            height: 1.2,
                           ),
                           overflow: TextOverflow.ellipsis,
                         ),
@@ -113,7 +113,7 @@ class HomeListItem extends StatelessWidget {
                           dDay != null ? '$dateRange $dDay' : dateRange,
                           style: AppTypography.caption3Regular.copyWith(
                             color: AppColors.status100_50,
-                            height: 1.0,
+                            height: 1.2,
                           ),
                         ),
                       ),
@@ -123,7 +123,7 @@ class HomeListItem extends StatelessWidget {
                           '${progress.toInt()}%',
                           style: AppTypography.caption3Bold.copyWith(
                             color: progress >= 100 ? AppColors.green300 : AppColors.status100_75,
-                            height: 1.0,
+                            height: 1.2,
                           ),
                         ),
                       ],
@@ -157,9 +157,14 @@ class HomeListItem extends StatelessWidget {
       decoration: BoxDecoration(
         shape: BoxShape.circle,
         color: backgroundColor,
-        border: borderColor != null ? Border.all(color: borderColor, width: 1) : null,
       ),
-      clipBehavior: Clip.antiAlias,
+      foregroundDecoration: borderColor != null
+          ? BoxDecoration(
+              shape: BoxShape.circle,
+              border: Border.all(color: borderColor, width: 1),
+            )
+          : null,
+      clipBehavior: Clip.antiAliasWithSaveLayer,
       child: isCustomIcon
           ? _buildIconFromPath(icon)
           : Padding(
@@ -262,7 +267,7 @@ class HomeListItem extends StatelessWidget {
         label,
         style: AppTypography.caption3Bold.copyWith(
           color: color,
-          height: 1.0,
+          height: 1.2,
         ),
       ),
     );

--- a/toondo/packages/presentation/lib/views/mypage/account_setting/nickname_change_screen.dart
+++ b/toondo/packages/presentation/lib/views/mypage/account_setting/nickname_change_screen.dart
@@ -30,14 +30,11 @@ class _NicknameChangeScreenState extends State<NicknameChangeScreen> {
 
     return BaseScaffold(
       title: '닉네임 변경',
-      body: LayoutBuilder(
-        builder: (context, constraints) {
-          final bottomInset = MediaQuery.of(context).viewInsets.bottom;
-          return SingleChildScrollView(
-            keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
-            padding: EdgeInsets.only(bottom: bottomInset + AppSpacing.v16),
-            child: ConstrainedBox(
-              constraints: BoxConstraints(minHeight: constraints.maxHeight),
+      body: Column(
+        children: [
+          Expanded(
+            child: SingleChildScrollView(
+              keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
               child: NicknameChangeBody(
                 controller: _newNicknameController,
                 currentNickname: currentNickname,
@@ -51,34 +48,28 @@ class _NicknameChangeScreenState extends State<NicknameChangeScreen> {
                 },
               ),
             ),
-          );
-        },
-      ),
-      bottomWidget: SafeArea(
-        child: Padding(
-          padding: EdgeInsets.symmetric(
-            horizontal: AppSpacing.h24,
-            vertical: AppSpacing.v8,
           ),
-          child: AppButton(
-            label: '변경하기',
-            onPressed: () async {
-              final success = await viewModel.updateNickname(
-                _newNicknameController.text,
-              );
-              if (success && mounted) {
-                Navigator.pop(context);
-                return;
-              }
-
-              if (mounted) {
-                setState(() {
-                  _nicknameError = viewModel.nicknameErrorMessage;
-                });
-              }
-            },
+          Padding(
+            padding: EdgeInsets.symmetric(vertical: AppSpacing.v16),
+            child: AppButton(
+              label: '변경하기',
+              onPressed: () async {
+                final success = await viewModel.updateNickname(
+                  _newNicknameController.text,
+                );
+                if (success && mounted) {
+                  Navigator.pop(context);
+                  return;
+                }
+                if (mounted) {
+                  setState(() {
+                    _nicknameError = viewModel.nicknameErrorMessage;
+                  });
+                }
+              },
+            ),
           ),
-        ),
+        ],
       ),
     );
   }

--- a/toondo/packages/presentation/lib/views/mypage/notification_setting/notification_setting_body.dart
+++ b/toondo/packages/presentation/lib/views/mypage/notification_setting/notification_setting_body.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:common/notification/exact_alarm_helper.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
@@ -100,7 +99,7 @@ Future<void> _onToggleReminder(
               ),
               SizedBox(height: AppSpacing.v8),
               Text(
-                '정확한 리마인드 알림을 받으려면 알림 권한이 필요해요.\n설정으로 이동할까요?',
+                '리마인드 알림을 받으려면 알림 권한이 필요해요.\n설정으로 이동할까요?',
                 textAlign: TextAlign.center,
                 style: AppTypography.body2Regular.copyWith(
                   color: const Color(0xFF535353),
@@ -116,11 +115,9 @@ Future<void> _onToggleReminder(
                         foregroundColor: AppColors.status100,
                         side: const BorderSide(color: Color(0xFFD9D9D9)),
                         shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(
-                              AppDimensions.radiusPill),
+                          borderRadius: BorderRadius.circular(AppDimensions.radiusPill),
                         ),
-                        padding:
-                        EdgeInsets.symmetric(vertical: 12.h),
+                        padding: EdgeInsets.symmetric(vertical: 12.h),
                       ),
                       onPressed: () => Navigator.of(ctx).pop(false),
                       child: Text('취소', style: AppTypography.body2SemiBold),
@@ -133,15 +130,12 @@ Future<void> _onToggleReminder(
                         backgroundColor: AppColors.green500,
                         foregroundColor: Colors.white,
                         shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(
-                              AppDimensions.radiusPill),
+                          borderRadius: BorderRadius.circular(AppDimensions.radiusPill),
                         ),
-                        padding:
-                        EdgeInsets.symmetric(vertical: 12.h),
+                        padding: EdgeInsets.symmetric(vertical: 12.h),
                       ),
                       onPressed: () => Navigator.of(ctx).pop(true),
-                      child: Text('설정 열기',
-                          style: AppTypography.body2SemiBold),
+                      child: Text('설정 열기', style: AppTypography.body2SemiBold),
                     ),
                   ),
                 ],
@@ -152,204 +146,8 @@ Future<void> _onToggleReminder(
       ),
     ) ?? false;
 
-    if (go) {
-      if (Platform.isAndroid) {
-        await openAppNotificationSettings();
-      } else {
-        await openAppSettings(); // iOS/기타
-      }
-    }
-    return; // 권한 받을 때까지 토글 켜지지 않음
-  }
-
-  if (Platform.isAndroid) {
-    if (!context.mounted) return;
-    final goExact = await showDialog<bool>(
-      context: context,
-      barrierDismissible: true,
-      builder: (ctx) => Dialog(
-        backgroundColor: Colors.white,
-        insetPadding: EdgeInsets.symmetric(horizontal: 24.w),
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(AppDimensions.borderRadius10),
-        ),
-        child: Padding(
-          padding: EdgeInsets.symmetric(horizontal: 24.w, vertical: 24.h),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              SizedBox(height: AppSpacing.v8),
-              Container(
-                width: 56.w,
-                height: 56.w,
-                decoration: const BoxDecoration(
-                  color: Color(0xFFE4F0D9),
-                  shape: BoxShape.circle,
-                ),
-                child: Icon(Icons.alarm_on_outlined,
-                    color: const Color(0xFF78B545), size: 28.w),
-              ),
-              SizedBox(height: AppSpacing.v12),
-              Text(
-                '정확한 알람 허용',
-                textAlign: TextAlign.center,
-                style: AppTypography.h2Bold.copyWith(letterSpacing: 0.15),
-              ),
-              SizedBox(height: AppSpacing.v8),
-              Text(
-                '정확한 알람이 꺼져 있으면 알림 시간이 지연될 수 있어요.\n설정에서 "정확한 알람"을 허용하시겠어요?',
-                textAlign: TextAlign.center,
-                style: AppTypography.body2Regular.copyWith(
-                  color: const Color(0xFF535353),
-                  letterSpacing: 0.15,
-                ),
-              ),
-              SizedBox(height: AppSpacing.v16),
-              Row(
-                children: [
-                  Expanded(
-                    child: OutlinedButton(
-                      style: OutlinedButton.styleFrom(
-                        foregroundColor: AppColors.status100,
-                        side: const BorderSide(color: Color(0xFFD9D9D9)),
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(
-                              AppDimensions.radiusPill),
-                        ),
-                        padding:
-                        EdgeInsets.symmetric(vertical: 12.h),
-                      ),
-                      onPressed: () => Navigator.of(ctx).pop(false),
-                      child: Text('건너뛰기',
-                          style: AppTypography.body2SemiBold),
-                    ),
-                  ),
-                  SizedBox(width: AppSpacing.h12),
-                  Expanded(
-                    child: ElevatedButton(
-                      style: ElevatedButton.styleFrom(
-                        backgroundColor: AppColors.green500,
-                        foregroundColor: Colors.white,
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(
-                              AppDimensions.radiusPill),
-                        ),
-                        padding:
-                        EdgeInsets.symmetric(vertical: 12.h),
-                      ),
-                      onPressed: () => Navigator.of(ctx).pop(true),
-                      child: Text('설정 열기',
-                          style: AppTypography.body2SemiBold),
-                    ),
-                  ),
-                ],
-              ),
-            ],
-          ),
-        ),
-      ),
-    ) ?? false;
-
-    if (goExact) {
-      await openExactAlarmSettings();
-    }
-
-    // 배터리 최적화 제외 요청 (실물 기기에서 Doze 모드로 알림 차단 방지)
-    final batteryStatus = await Permission.ignoreBatteryOptimizations.status;
-    if (!batteryStatus.isGranted) {
-      await Permission.ignoreBatteryOptimizations.request();
-    }
-
-    // 삼성 갤럭시 전용: One UI 자체 배터리 제한 안내
-    if (!context.mounted) return;
-    final samsung = await isSamsungDevice();
-    if (samsung && context.mounted) {
-      final goSamsung = await showDialog<bool>(
-        context: context,
-        barrierDismissible: true,
-        builder: (ctx) => Dialog(
-          backgroundColor: Colors.white,
-          insetPadding: EdgeInsets.symmetric(horizontal: 24.w),
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(AppDimensions.borderRadius10),
-          ),
-          child: Padding(
-            padding: EdgeInsets.symmetric(horizontal: 24.w, vertical: 24.h),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                SizedBox(height: AppSpacing.v8),
-                Container(
-                  width: 56.w,
-                  height: 56.w,
-                  decoration: const BoxDecoration(
-                    color: Color(0xFFE4F0D9),
-                    shape: BoxShape.circle,
-                  ),
-                  child: Icon(Icons.battery_charging_full_outlined,
-                      color: const Color(0xFF78B545), size: 28.w),
-                ),
-                SizedBox(height: AppSpacing.v12),
-                Text(
-                  '갤럭시 배터리 설정 필요',
-                  textAlign: TextAlign.center,
-                  style: AppTypography.h2Bold.copyWith(letterSpacing: 0.15),
-                ),
-                SizedBox(height: AppSpacing.v8),
-                Text(
-                  '갤럭시 기기는 추가 설정이 필요해요.\n설정 > 앱 > ToonDo > 배터리에서\n"제한 없음"으로 변경해주세요.',
-                  textAlign: TextAlign.center,
-                  style: AppTypography.body2Regular.copyWith(
-                    color: const Color(0xFF535353),
-                    letterSpacing: 0.15,
-                  ),
-                ),
-                SizedBox(height: AppSpacing.v16),
-                Row(
-                  children: [
-                    Expanded(
-                      child: OutlinedButton(
-                        style: OutlinedButton.styleFrom(
-                          foregroundColor: AppColors.status100,
-                          side: const BorderSide(color: Color(0xFFD9D9D9)),
-                          shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(
-                                AppDimensions.radiusPill),
-                          ),
-                          padding: EdgeInsets.symmetric(vertical: 12.h),
-                        ),
-                        onPressed: () => Navigator.of(ctx).pop(false),
-                        child: Text('건너뛰기', style: AppTypography.body2SemiBold),
-                      ),
-                    ),
-                    SizedBox(width: AppSpacing.h12),
-                    Expanded(
-                      child: ElevatedButton(
-                        style: ElevatedButton.styleFrom(
-                          backgroundColor: AppColors.green500,
-                          foregroundColor: Colors.white,
-                          shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(
-                                AppDimensions.radiusPill),
-                          ),
-                          padding: EdgeInsets.symmetric(vertical: 12.h),
-                        ),
-                        onPressed: () => Navigator.of(ctx).pop(true),
-                        child: Text('설정 열기', style: AppTypography.body2SemiBold),
-                      ),
-                    ),
-                  ],
-                ),
-              ],
-            ),
-          ),
-        ),
-      ) ?? false;
-
-      if (goSamsung) {
-        await openSamsungBatterySettings();
-      }
-    }
+    if (go) await openAppNotificationSettings();
+    return;
   }
 
   await appVM.update(settings.copyWith(all: true, reminder: true));

--- a/toondo/packages/presentation/lib/views/mypage/notification_setting/notification_setting_body.dart
+++ b/toondo/packages/presentation/lib/views/mypage/notification_setting/notification_setting_body.dart
@@ -253,6 +253,103 @@ Future<void> _onToggleReminder(
     if (goExact) {
       await openExactAlarmSettings();
     }
+
+    // 배터리 최적화 제외 요청 (실물 기기에서 Doze 모드로 알림 차단 방지)
+    final batteryStatus = await Permission.ignoreBatteryOptimizations.status;
+    if (!batteryStatus.isGranted) {
+      await Permission.ignoreBatteryOptimizations.request();
+    }
+
+    // 삼성 갤럭시 전용: One UI 자체 배터리 제한 안내
+    if (!context.mounted) return;
+    final samsung = await isSamsungDevice();
+    if (samsung && context.mounted) {
+      final goSamsung = await showDialog<bool>(
+        context: context,
+        barrierDismissible: true,
+        builder: (ctx) => Dialog(
+          backgroundColor: Colors.white,
+          insetPadding: EdgeInsets.symmetric(horizontal: 24.w),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(AppDimensions.borderRadius10),
+          ),
+          child: Padding(
+            padding: EdgeInsets.symmetric(horizontal: 24.w, vertical: 24.h),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                SizedBox(height: AppSpacing.v8),
+                Container(
+                  width: 56.w,
+                  height: 56.w,
+                  decoration: const BoxDecoration(
+                    color: Color(0xFFE4F0D9),
+                    shape: BoxShape.circle,
+                  ),
+                  child: Icon(Icons.battery_charging_full_outlined,
+                      color: const Color(0xFF78B545), size: 28.w),
+                ),
+                SizedBox(height: AppSpacing.v12),
+                Text(
+                  '갤럭시 배터리 설정 필요',
+                  textAlign: TextAlign.center,
+                  style: AppTypography.h2Bold.copyWith(letterSpacing: 0.15),
+                ),
+                SizedBox(height: AppSpacing.v8),
+                Text(
+                  '갤럭시 기기는 추가 설정이 필요해요.\n설정 > 앱 > ToonDo > 배터리에서\n"제한 없음"으로 변경해주세요.',
+                  textAlign: TextAlign.center,
+                  style: AppTypography.body2Regular.copyWith(
+                    color: const Color(0xFF535353),
+                    letterSpacing: 0.15,
+                  ),
+                ),
+                SizedBox(height: AppSpacing.v16),
+                Row(
+                  children: [
+                    Expanded(
+                      child: OutlinedButton(
+                        style: OutlinedButton.styleFrom(
+                          foregroundColor: AppColors.status100,
+                          side: const BorderSide(color: Color(0xFFD9D9D9)),
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(
+                                AppDimensions.radiusPill),
+                          ),
+                          padding: EdgeInsets.symmetric(vertical: 12.h),
+                        ),
+                        onPressed: () => Navigator.of(ctx).pop(false),
+                        child: Text('건너뛰기', style: AppTypography.body2SemiBold),
+                      ),
+                    ),
+                    SizedBox(width: AppSpacing.h12),
+                    Expanded(
+                      child: ElevatedButton(
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: AppColors.green500,
+                          foregroundColor: Colors.white,
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(
+                                AppDimensions.radiusPill),
+                          ),
+                          padding: EdgeInsets.symmetric(vertical: 12.h),
+                        ),
+                        onPressed: () => Navigator.of(ctx).pop(true),
+                        child: Text('설정 열기', style: AppTypography.body2SemiBold),
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      ) ?? false;
+
+      if (goSamsung) {
+        await openSamsungBatterySettings();
+      }
+    }
   }
 
   await appVM.update(settings.copyWith(all: true, reminder: true));

--- a/toondo/packages/presentation/lib/views/onboarding/onboarding_background.dart
+++ b/toondo/packages/presentation/lib/views/onboarding/onboarding_background.dart
@@ -29,11 +29,11 @@ class OnboardingBackground extends StatelessWidget {
       children: [
         // 하얀 타원 배경
         Positioned(
-          left: -79.64,
-          top: 538.34,
+          left: -80,
+          top: 538,
           child: Container(
-            width: 534.28,
-            height: 483.32,
+            width: 534,
+            height: 483,
             decoration: ShapeDecoration(
               gradient: LinearGradient(
                 begin: Alignment(0.38, -0.93),

--- a/toondo/packages/presentation/lib/views/onboarding/step3/onboarding_step3_screen.dart
+++ b/toondo/packages/presentation/lib/views/onboarding/step3/onboarding_step3_screen.dart
@@ -41,6 +41,7 @@ class OnboardingStep3Screen extends StatelessWidget {
     });
 
     return Scaffold(
+      resizeToAvoidBottomInset: false, // 배경 고정, 키보드 inset은 bottomInset으로 수동 처리
       appBar: AppNavBar(
         title: '시작하기',
         showBackButton: false,

--- a/toondo/packages/presentation/lib/views/welcome/welcome_body.dart
+++ b/toondo/packages/presentation/lib/views/welcome/welcome_body.dart
@@ -108,12 +108,15 @@ class WelcomeBody extends StatelessWidget {
   Widget _buildTermsText() {
     return SafeArea(
       top: false,
-      child: Text(
-          '버튼을 눌러 다음 화면으로 이동 시,\n서비스 이용 약관 및 개인정보 처리 방안에 동의한 것으로 간주합니다.',
-          textAlign: TextAlign.center,
-          style: AppTypography.caption3Regular.copyWith(
-            color: AppColors.green600
-          ),
+      child: Padding(
+        padding: const EdgeInsets.only(bottom: 12),
+        child: Text(
+            '버튼을 눌러 다음 화면으로 이동 시,\n서비스 이용 약관 및 개인정보 처리 방안에 동의한 것으로 간주합니다.',
+            textAlign: TextAlign.center,
+            style: AppTypography.caption3Regular.copyWith(
+              color: AppColors.green600
+            ),
+        ),
       ),
     );
   }

--- a/toondo/pubspec.yaml
+++ b/toondo/pubspec.yaml
@@ -42,6 +42,7 @@ dependencies:
   injectable: ^2.5.0
   flutter_screenutil: ^5.9.3
   package_info_plus: ^8.3.0
+  device_info_plus: ^10.0.0
   flutter_gen:
   flutter_localizations:
     sdk: flutter


### PR DESCRIPTION
## Summary

### 🔔 fix(notification): 갤럭시 최신 실물 기기 리마인드 알림 수신 불가 문제 수정

에뮬레이터에서는 정상 동작하지만 실물 기기에서 리마인드 알림이 오지 않는 문제를 수정했습니다.

**원인**
- `_inited = true`가 async 작업 시작 전에 설정되어, 채널 생성 실패 시에도 재시도 불가
- 앱 시작 시 알림 sync 타임아웃(3초)이 실물 기기에서 너무 짧아 알람 미등록
- `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` 권한 누락으로 Doze 모드에서 알림 차단
- 핵심 : **삼성 One UI의 자체 배터리 제한 레이어 미대응**

**수정 내용**
- `_inited = true` 위치를 모든 async 작업 완료 후로 이동
- 알림 sync 타임아웃 3초 → 10초
- `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` 권한 추가 (AndroidManifest)
- 리마인드 ON 시 배터리 최적화 제외 자동 요청
- 삼성 기기 감지 후 One UI 배터리 설정(제한 없음) 안내 다이얼로그 추가
- `device_info_plus` 패키지 추가

---

### 🎨 fix(ui): 픽셀 정렬 오류 및 텍스트 블러리 이슈 개선

**수정 내용**
- `speech_bubble.dart` CustomPainter 좌표 소수점 → `.roundToDouble()` 처리
- `onboarding_background.dart` Positioned 소수점 하드코딩 좌표 정수화
- `home_list_item.dart` 등 `height: 1.0` → `1.2` (ascender/descender 크롭 방지)
- 기타 레이아웃 픽셀 정렬 정리

---

### ✨ feat(auth): 회원가입·로그인 화면 텍스트 입력 UX 개선

- 회원가입 Step1/Step2 텍스트 입력 흐름 개선 (입력폼 클릭 시 버튼 하단에 위치하는 불편함 해소)
- 로그인 화면 UX 개선
- 목표 이름 입력 필드 개선
